### PR TITLE
fix streaming compatibility: forward block through non-pipeline chat_single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion LLM Changelog
 
+## [0.4.7] - 2026-03-23
+
+### Fixed
+- `Legion::LLM.chat(message:) { |chunk| chunk.content }` now streams when `pipeline_enabled: false`; block is forwarded through `chat_single` to `session.ask` rather than silently ignored
+
+### Added
+- Integration specs verifying pipeline streaming yields chunks with `.content`, `caller:` flows through to `response.caller`, and non-pipeline streaming works
+
 ## [0.4.6] - 2026-03-23
 
 ### Changed

--- a/lib/legion/llm.rb
+++ b/lib/legion/llm.rb
@@ -219,6 +219,11 @@ module Legion
                                    quality_check: quality_check, **kwargs, &)
         end
 
+        if block_given? && message
+          return chat_single(model: model, provider: provider, intent: intent, tier: tier,
+                             message: message, **kwargs, &)
+        end
+
         messages = message.is_a?(Array) ? message : [{ role: 'user', content: message.to_s }]
         resolved_model = model || settings[:default_model]
 
@@ -277,7 +282,7 @@ module Legion
         }
       end
 
-      def chat_single(model:, provider:, intent:, tier:, message: nil, **kwargs) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+      def chat_single(model:, provider:, intent:, tier:, message: nil, **kwargs, &block) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
         explicit_tools = kwargs.delete(:tools)
         tools = explicit_tools || ToolRegistry.tools
         tools = nil if tools.empty?
@@ -313,7 +318,7 @@ module Legion
         return session unless message
 
         Legion::Logging.debug '[LLM] chat_single calling session.ask' if defined?(Legion::Logging)
-        response = session.ask(message)
+        response = block ? session.ask(message, &block) : session.ask(message)
         Legion::Logging.debug "[LLM] chat_single response_class=#{response.class} response_nil=#{response.nil?}" if defined?(Legion::Logging)
         response
       end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.4.6'
+    VERSION = '0.4.7'
   end
 end

--- a/spec/legion/llm/pipeline/streaming_integration_spec.rb
+++ b/spec/legion/llm/pipeline/streaming_integration_spec.rb
@@ -59,4 +59,54 @@ RSpec.describe 'Pipeline streaming end-to-end' do
 
     expect(store_called_during_stream).to be false
   end
+
+  it 'yields chunks with a .content method when pipeline is enabled' do
+    chunk1 = double('chunk1', content: 'Hello ')
+    chunk2 = double('chunk2', content: 'world')
+    mock_session = double('session', with_tool: nil)
+    allow(RubyLLM).to receive(:chat).and_return(mock_session)
+    mock_response = double('response', content: 'Hello world', input_tokens: 10, output_tokens: 5, tool_calls: nil)
+    allow(mock_response).to receive(:respond_to?).and_return(true)
+    allow(mock_response).to receive(:respond_to?).with(:tool_calls).and_return(false)
+    allow(mock_session).to receive(:ask).and_yield(chunk1).and_yield(chunk2).and_return(mock_response)
+
+    chunks = []
+    result = Legion::LLM.chat(message: 'test') { |chunk| chunks << chunk }
+
+    expect(chunks.map(&:content)).to eq(['Hello ', 'world'])
+    expect(result).to be_a(Legion::LLM::Pipeline::Response)
+    expect(result.message[:content]).to eq('Hello world')
+  end
+
+  it 'forwards caller: to response.caller in pipeline streaming mode' do
+    mock_session = double('session', with_tool: nil)
+    allow(RubyLLM).to receive(:chat).and_return(mock_session)
+    mock_response = double('response', content: 'ok', input_tokens: 3, output_tokens: 2, tool_calls: nil)
+    allow(mock_response).to receive(:respond_to?).and_return(true)
+    allow(mock_response).to receive(:respond_to?).with(:tool_calls).and_return(false)
+    allow(mock_session).to receive(:ask).and_return(mock_response)
+
+    caller_val = { requested_by: { type: :external, identity: 'acp:my_runner' } }
+    result = Legion::LLM.chat(message: 'test', caller: caller_val) { |_chunk| nil }
+
+    expect(result.caller).to eq(caller_val)
+  end
+
+  context 'when pipeline_enabled: false' do
+    before { Legion::Settings[:llm][:pipeline_enabled] = false }
+
+    it 'streams chunks via direct path when a block is given' do
+      chunk1 = double('chunk1', content: 'Hi ')
+      chunk2 = double('chunk2', content: 'there')
+      mock_session = double('session', with_tool: nil)
+      allow(RubyLLM).to receive(:chat).and_return(mock_session)
+      mock_response = double('response', content: 'Hi there', input_tokens: 5, output_tokens: 4)
+      allow(mock_session).to receive(:ask).and_yield(chunk1).and_yield(chunk2).and_return(mock_response)
+
+      chunks = []
+      Legion::LLM.chat(message: 'test') { |chunk| chunks << chunk }
+
+      expect(chunks.map(&:content)).to eq(['Hi ', 'there'])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Legion::LLM.chat(message: msg) { |chunk| chunk.content }` was silently dropping the streaming block when `pipeline_enabled: false` — `_dispatch_chat` only forwarded blocks to `chat_via_pipeline`, the `chat_direct` path ignored them entirely
- Add a non-pipeline streaming branch in `_dispatch_chat`: when a block is given and pipeline is disabled, route directly to `chat_single` (bypassing caching/escalation machinery that doesn't apply to streams)
- Add `&block` parameter to `chat_single`, forward to `session.ask` — real RubyLLM chunks with `.content` are yielded to the caller's block

## Specs added (`streaming_integration_spec.rb`)

- **chunks with `.content`**: verifies pipeline streaming yields chunk objects responding to `.content`, final response is `Pipeline::Response` with correct content
- **`caller:` forwarding**: verifies `caller:` hash flows through pipeline streaming to `response.caller`
- **non-pipeline streaming**: verifies `pipeline_enabled: false` + block correctly streams chunks via `chat_single`

## Test plan

- [ ] `bundle exec rspec` — 862 examples, 0 failures
- [ ] `bundle exec rubocop` — 151 files, 0 offenses