### PR TITLE
auto-enable classification step under compliance profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.5.13] - 2026-03-27
+
+### Changed
+- Classification step (step 6) now auto-enables when `Settings.dig(:compliance, :classification_level)` is set, making it opt-out instead of opt-in when compliance profile is active
+
 ## [0.5.12] - 2026-03-26
 
 ### Added

--- a/lib/legion/llm/pipeline/steps/classification.rb
+++ b/lib/legion/llm/pipeline/steps/classification.rb
@@ -20,9 +20,9 @@ module Legion
           ].freeze
 
           def step_classification
-            return unless @request.classification
+            return unless @request.classification || compliance_classification_default
 
-            classification  = @request.classification
+            classification  = @request.classification || compliance_classification_default
             declared_level  = classification[:level]
             scan            = scan_content_for_sensitive_data
             effective_level = upgrade_if_needed(declared_level, scan)
@@ -91,6 +91,17 @@ module Legion
             return declared_level if current_idx >= threshold_idx
 
             LEVELS[threshold_idx]
+          end
+
+          def compliance_classification_default
+            return nil unless defined?(Legion::Settings)
+
+            level = Legion::Settings.dig(:compliance, :classification_level)
+            return nil unless level
+
+            { level: level.to_sym }
+          rescue StandardError
+            nil
           end
         end
       end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.5.12'
+    VERSION = '0.5.13'
   end
 end


### PR DESCRIPTION
## Summary
- Classification step (step 6) now auto-enables when `Settings.dig(:compliance, :classification_level)` is set
- Makes classification opt-out instead of opt-in under the max-classification compliance profile
- Companion to LegionIO PR that registers compliance defaults with `classification_level: 'confidential'`
- Bump to 0.5.13

## Test plan
- [x] `bundle exec rspec` — 924 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] Existing classification step specs still pass (15 examples)