### PR TITLE
add DaemonClient.inference for conversation-level routing (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion LLM Changelog
 
+## [0.5.14] - 2026-03-27
+
+### Added
+- `DaemonClient.inference` method for conversation-level routing — accepts a full `messages:` array and optional `tools:`, `model:`, `provider:`, and `timeout:` keyword args, posts to `POST /api/llm/inference`, and returns a structured `{ status: :ok, data: { content:, tool_calls:, stop_reason:, model:, input_tokens:, output_tokens: } }` hash on success
+- `http_post` now accepts an optional `timeout:` keyword argument (default `DEFAULT_TIMEOUT = 60`) so callers like `inference` can pass a longer timeout (120s) without affecting existing `chat` calls
+- `interpret_inference_response` private helper that maps the `/api/llm/inference` HTTP response — 200 returns `:ok` with structured fields, 4xx/5xx follow the same error handling as `interpret_response`
+
 ## [0.5.13] - 2026-03-27
 
 ### Changed

--- a/lib/legion/llm/daemon_client.rb
+++ b/lib/legion/llm/daemon_client.rb
@@ -102,13 +102,29 @@ module Legion
         http.request(request)
       end
 
+      # POSTs a conversation-level inference request to the daemon REST API.
+      # Accepts a full messages array and optional tool schemas.
+      # Returns a status hash with structured inference fields on success.
+      def inference(messages:, tools: [], model: nil, provider: nil, timeout: 120)
+        body = { messages: messages, tools: tools }
+        body[:model]    = model    if model
+        body[:provider] = provider if provider
+
+        response = http_post('/api/llm/inference', body, timeout: timeout)
+        interpret_inference_response(response)
+      rescue StandardError => e
+        mark_unhealthy
+        { status: :unavailable, error: e.message }
+      end
+
       # Builds and sends a POST request with a JSON body.
       # Returns Net::HTTPResponse.
-      def http_post(path, body)
+      # The optional timeout: keyword overrides the default read timeout.
+      def http_post(path, body, timeout: DEFAULT_TIMEOUT)
         uri     = URI.parse("#{daemon_url}#{path}")
         http    = Net::HTTP.new(uri.host, uri.port)
         http.open_timeout = 5
-        http.read_timeout = DEFAULT_TIMEOUT
+        http.read_timeout = timeout
         request = Net::HTTP::Post.new(uri.request_uri)
         request['Content-Type'] = 'application/json'
         request.body = ::JSON.dump(body)
@@ -180,7 +196,44 @@ module Legion
         0
       end
 
-      private_class_method :fetch_daemon_url, :safe_parse, :extract_retry_after
+      # Maps an HTTP response from /api/llm/inference to a structured status hash.
+      # On 200 returns :ok with structured inference fields extracted from the body.
+      # All other codes follow the same error handling as interpret_response.
+      def interpret_inference_response(response)
+        code   = response.code.to_i
+        parsed = safe_parse(response.body)
+
+        if code == 200
+          data = parsed.fetch(:data, parsed)
+          return {
+            status: :ok,
+            data:   {
+              content:       data[:content],
+              tool_calls:    data[:tool_calls] || [],
+              stop_reason:   data[:stop_reason],
+              model:         data[:model],
+              input_tokens:  data[:input_tokens],
+              output_tokens: data[:output_tokens]
+            }
+          }
+        end
+
+        case code
+        when 403
+          Legion::Logging.warn("Daemon returned 403 Denied url=#{daemon_url}") if defined?(Legion::Logging)
+          { status: :denied, error: parsed.fetch(:error, parsed) }
+        when 429
+          retry_after = extract_retry_after(response, parsed)
+          Legion::Logging.warn("Daemon returned 429 RateLimited url=#{daemon_url} retry_after=#{retry_after}") if defined?(Legion::Logging)
+          { status: :rate_limited, retry_after: retry_after }
+        when 503
+          { status: :unavailable }
+        else
+          { status: :error, code: code, body: parsed }
+        end
+      end
+
+      private_class_method :fetch_daemon_url, :safe_parse, :extract_retry_after, :interpret_inference_response
     end
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.5.13'
+    VERSION = '0.5.14'
   end
 end

--- a/spec/legion/llm/daemon_client_spec.rb
+++ b/spec/legion/llm/daemon_client_spec.rb
@@ -513,4 +513,226 @@ RSpec.describe Legion::LLM::DaemonClient do
       end
     end
   end
+
+  # ──────────────────────────────────────────────
+  # http_post timeout keyword
+  # ──────────────────────────────────────────────
+  describe '.http_post timeout override' do
+    before do
+      allow(Legion::LLM).to receive(:settings).and_return({ daemon: { url: 'http://localhost:4000' } })
+    end
+
+    it 'uses DEFAULT_TIMEOUT when no timeout argument is given' do
+      http = double('Net::HTTP')
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:request).and_return(double('Response', code: '200', body: '{}'))
+      expect(http).to receive(:read_timeout=).with(described_class::DEFAULT_TIMEOUT)
+      allow(Net::HTTP).to receive(:new).and_return(http)
+
+      described_class.http_post('/api/llm/chat', {})
+    end
+
+    it 'uses a custom timeout when provided' do
+      http = double('Net::HTTP')
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:request).and_return(double('Response', code: '200', body: '{}'))
+      expect(http).to receive(:read_timeout=).with(120)
+      allow(Net::HTTP).to receive(:new).and_return(http)
+
+      described_class.http_post('/api/llm/inference', {}, timeout: 120)
+    end
+  end
+
+  # ──────────────────────────────────────────────
+  # inference
+  # ──────────────────────────────────────────────
+  describe '.inference' do
+    before do
+      allow(Legion::LLM).to receive(:settings).and_return({ daemon: { url: 'http://localhost:4000' } })
+    end
+
+    context 'when daemon returns 200 with content' do
+      it 'returns status :ok with structured data' do
+        payload = { data: { content: 'The answer is 42', tool_calls: [], stop_reason: 'end_turn',
+                            model: 'claude-sonnet-4-6', input_tokens: 10, output_tokens: 5 } }
+        response = double('Response', code: '200', body: JSON.dump(payload))
+        allow(response).to receive(:[]).and_return(nil)
+        allow(described_class).to receive(:http_post).and_return(response)
+
+        result = described_class.inference(messages: [{ role: 'user', content: 'hello' }])
+        expect(result[:status]).to eq(:ok)
+        expect(result[:data][:content]).to eq('The answer is 42')
+        expect(result[:data][:tool_calls]).to eq([])
+        expect(result[:data][:stop_reason]).to eq('end_turn')
+        expect(result[:data][:model]).to eq('claude-sonnet-4-6')
+        expect(result[:data][:input_tokens]).to eq(10)
+        expect(result[:data][:output_tokens]).to eq(5)
+      end
+    end
+
+    context 'when daemon returns 200 with tool_calls' do
+      it 'returns status :ok and preserves tool_calls array' do
+        tool_call = { id: 'call_1', name: 'search', arguments: { query: 'ruby docs' } }
+        payload = { data: { content: nil, tool_calls: [tool_call], stop_reason: 'tool_use',
+                            model: 'claude-sonnet-4-6', input_tokens: 20, output_tokens: 8 } }
+        response = double('Response', code: '200', body: JSON.dump(payload))
+        allow(response).to receive(:[]).and_return(nil)
+        allow(described_class).to receive(:http_post).and_return(response)
+
+        result = described_class.inference(messages: [{ role: 'user', content: 'search for ruby docs' }])
+        expect(result[:status]).to eq(:ok)
+        expect(result[:data][:tool_calls].length).to eq(1)
+        expect(result[:data][:stop_reason]).to eq('tool_use')
+      end
+    end
+
+    context 'when daemon returns 200 and tool_calls is absent from body' do
+      it 'defaults tool_calls to an empty array' do
+        payload = { data: { content: 'hello', stop_reason: 'end_turn', model: 'gpt-4o',
+                            input_tokens: 5, output_tokens: 2 } }
+        response = double('Response', code: '200', body: JSON.dump(payload))
+        allow(response).to receive(:[]).and_return(nil)
+        allow(described_class).to receive(:http_post).and_return(response)
+
+        result = described_class.inference(messages: [])
+        expect(result[:data][:tool_calls]).to eq([])
+      end
+    end
+
+    context 'request body construction' do
+      it 'sends messages and tools to /api/llm/inference' do
+        response = double('Response', code: '200',
+                                      body: JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',
+                                                    model: 'x', input_tokens: 1, output_tokens: 1 } }))
+        allow(response).to receive(:[]).and_return(nil)
+        messages = [{ role: 'user', content: 'hi' }]
+        tools    = [{ name: 'calculator', description: 'does math' }]
+
+        expect(described_class).to receive(:http_post) do |path, body_hash, **_kwargs|
+          expect(path).to eq('/api/llm/inference')
+          expect(body_hash[:messages]).to eq(messages)
+          expect(body_hash[:tools]).to eq(tools)
+          response
+        end
+
+        described_class.inference(messages: messages, tools: tools)
+      end
+
+      it 'omits model key when model is nil' do
+        response = double('Response', code: '200',
+                                      body: JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',
+                                                    model: 'x', input_tokens: 1, output_tokens: 1 } }))
+        allow(response).to receive(:[]).and_return(nil)
+
+        expect(described_class).to receive(:http_post) do |_path, body_hash, **_kwargs|
+          expect(body_hash).not_to have_key(:model)
+          response
+        end
+
+        described_class.inference(messages: [])
+      end
+
+      it 'includes model and provider when provided' do
+        response = double('Response', code: '200',
+                                      body: JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',
+                                                    model: 'x', input_tokens: 1, output_tokens: 1 } }))
+        allow(response).to receive(:[]).and_return(nil)
+
+        expect(described_class).to receive(:http_post) do |_path, body_hash, **_kwargs|
+          expect(body_hash[:model]).to eq('claude-sonnet-4-6')
+          expect(body_hash[:provider]).to eq(:anthropic)
+          response
+        end
+
+        described_class.inference(messages: [], model: 'claude-sonnet-4-6', provider: :anthropic)
+      end
+
+      it 'passes the timeout override to http_post' do
+        response = double('Response', code: '200',
+                                      body: JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',
+                                                    model: 'x', input_tokens: 1, output_tokens: 1 } }))
+        allow(response).to receive(:[]).and_return(nil)
+
+        expect(described_class).to receive(:http_post)
+          .with('/api/llm/inference', anything, timeout: 120)
+          .and_return(response)
+
+        described_class.inference(messages: [])
+      end
+
+      it 'passes a custom timeout when provided' do
+        response = double('Response', code: '200',
+                                      body: JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',
+                                                    model: 'x', input_tokens: 1, output_tokens: 1 } }))
+        allow(response).to receive(:[]).and_return(nil)
+
+        expect(described_class).to receive(:http_post)
+          .with('/api/llm/inference', anything, timeout: 300)
+          .and_return(response)
+
+        described_class.inference(messages: [], timeout: 300)
+      end
+    end
+
+    context 'error response codes' do
+      it 'returns :denied for 403' do
+        body = JSON.dump({ error: { message: 'Access denied' } })
+        response = double('Response', code: '403', body: body)
+        allow(response).to receive(:[]).and_return(nil)
+        allow(described_class).to receive(:http_post).and_return(response)
+
+        result = described_class.inference(messages: [])
+        expect(result[:status]).to eq(:denied)
+        expect(result[:error]).to be_a(Hash)
+      end
+
+      it 'returns :rate_limited for 429 with retry_after' do
+        body = JSON.dump({ error: { retry_after: 30 } })
+        response = double('Response', code: '429', body: body)
+        allow(response).to receive(:[]).with('Retry-After').and_return(nil)
+        allow(described_class).to receive(:http_post).and_return(response)
+
+        result = described_class.inference(messages: [])
+        expect(result[:status]).to eq(:rate_limited)
+        expect(result[:retry_after]).to eq(30)
+      end
+
+      it 'returns :unavailable for 503' do
+        response = double('Response', code: '503', body: '')
+        allow(response).to receive(:[]).and_return(nil)
+        allow(described_class).to receive(:http_post).and_return(response)
+
+        result = described_class.inference(messages: [])
+        expect(result[:status]).to eq(:unavailable)
+      end
+
+      it 'returns :error with code for 500' do
+        body = JSON.dump({ error: { message: 'Internal error' } })
+        response = double('Response', code: '500', body: body)
+        allow(response).to receive(:[]).and_return(nil)
+        allow(described_class).to receive(:http_post).and_return(response)
+
+        result = described_class.inference(messages: [])
+        expect(result[:status]).to eq(:error)
+        expect(result[:code]).to eq(500)
+      end
+    end
+
+    context 'when a network error occurs' do
+      it 'returns :unavailable status with the error message' do
+        allow(described_class).to receive(:http_post).and_raise(Errno::ECONNREFUSED, 'connection refused')
+
+        result = described_class.inference(messages: [])
+        expect(result[:status]).to eq(:unavailable)
+        expect(result[:error]).to be_a(String)
+      end
+
+      it 'marks the daemon as unhealthy' do
+        allow(described_class).to receive(:http_post).and_raise(Errno::ECONNREFUSED, 'connection refused')
+        expect(described_class).to receive(:mark_unhealthy)
+
+        described_class.inference(messages: [])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `DaemonClient.inference(messages:, tools: [], model: nil, provider: nil, timeout: 120)` — a new module method that POSTs a full messages array and tool schemas to `POST /api/llm/inference` on the daemon, enabling `legion chat` to route LLM requests through the daemon
- `http_post` gains an optional `timeout:` keyword arg (defaults to `DEFAULT_TIMEOUT = 60`) for backward compat; `inference` passes 120 to handle longer conversations
- `interpret_inference_response` private helper parses the inference endpoint response: 200 → `{ status: :ok, data: { content:, tool_calls:, stop_reason:, model:, input_tokens:, output_tokens: } }`; 4xx/5xx follow the same pattern as `interpret_response`

## Test plan

- [x] `bundle exec rspec` — 940 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] 16 new specs in `spec/legion/llm/daemon_client_spec.rb`:
  - Correct path and body sent to `/api/llm/inference`
  - `model`/`provider` included only when non-nil
  - Default 120s timeout forwarded to `http_post`; custom timeout override respected
  - 200 with `content` → `:ok` with all structured fields
  - 200 with `tool_calls` → preserves array
  - 200 without `tool_calls` → defaults to `[]`
  - 403 → `:denied`, 429 → `:rate_limited` with `retry_after`, 503 → `:unavailable`, 500 → `:error`
  - Network failure → `:unavailable` + `mark_unhealthy` called
- [x] Version bumped 0.5.13 → 0.5.14
- [x] CHANGELOG updated

Closes #16