### PR TITLE
add provider health checks, credential recovery, and direct ollama embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [0.5.21] - 2026-03-31
+
+### Added
+- Provider health checks at boot: each SaaS provider is pinged with a test request; failures disable the provider with a log warning
+- `resolve_llm_secrets` — resolves `env://` and `vault://` URIs in LLM settings before provider configuration (fixes late-loaded settings not being resolved)
+- `CodexConfigLoader.read_token` — extracts valid Codex auth token for fallback credential recovery
+- Credential recovery: when OpenAI fails health check, automatically tries `~/.codex/auth.json` token as fallback
+- Provider summary log after health checks listing all available providers
+- All-providers-down error log when no providers survive health checks
+- Embedding health check for SaaS providers during boot (Ollama skipped — model-pulled check is sufficient)
+- Direct Ollama embedding via `POST /api/embed` — bypasses RubyLLM which doesn't support Ollama embeddings
+- Pipeline executor provider fallback: on auth/forbidden errors, automatically retries with next enabled provider
+- `RubyLLM::Error` subclasses now caught in pipeline executor (previously only Faraday errors were rescued)
+
+### Changed
+- Bedrock default model corrected from `us.anthropic.claude-sonnet-4-6-v1` to `us.anthropic.claude-sonnet-4-6`
+- Ollama default model changed from `llama3` to `qwen3.5:latest`
+- `nomic-embed-text` added as first preference in `ollama_preferred` embedding models
+- `Discovery::Ollama.model_available?` now uses prefix matching (`mxbai-embed-large` matches `mxbai-embed-large:latest`)
+- Removed redundant `ping_provider` — replaced by `verify_providers` which checks all enabled SaaS providers
+- `ModelNotFoundError` during health check no longer disables the provider (RubyLLM registry gap, not auth failure)
+
 ## [0.5.20] - 2026-03-30
 
 ### Added

--- a/lib/legion/llm.rb
+++ b/lib/legion/llm.rb
@@ -48,7 +48,9 @@ module Legion
         require 'legion/llm/codex_config_loader'
         CodexConfigLoader.load
 
+        resolve_llm_secrets
         configure_providers
+        verify_providers
         run_discovery
         detect_embedding_capability
         set_defaults
@@ -59,7 +61,6 @@ module Legion
         Legion::Settings[:llm][:connected] = true
         Legion::Logging.info 'Legion::LLM started'
         register_routes
-        ping_provider
       end
 
       def shutdown
@@ -219,6 +220,14 @@ module Legion
                           principal_type caller].freeze
 
       private
+
+      def resolve_llm_secrets
+        return unless defined?(Legion::Settings::Resolver)
+
+        Legion::Settings::Resolver.resolve_secrets!(settings)
+      rescue StandardError => e
+        Legion::Logging.warn "LLM settings resolution failed: #{e.message}" if defined?(Legion::Logging)
+      end
 
       def pipeline_enabled?
         settings[:pipeline_enabled] == true
@@ -603,9 +612,28 @@ module Legion
           next unless available
 
           resolved_model = available.is_a?(String) ? available : model&.to_s
+          next unless verify_embedding(provider, resolved_model)
+
           return { provider: provider, model: resolved_model }
         end
         nil
+      end
+
+      def verify_embedding(provider, model)
+        return true if provider == :ollama
+        return true unless model
+
+        start_time = Time.now
+        RubyLLM.embed('health check', model: model, provider: provider)
+        elapsed = ((Time.now - start_time) * 1000).round
+        Legion::Logging.info "Embedding health check #{provider}/#{model}: OK (#{elapsed}ms)"
+        true
+      rescue RubyLLM::ModelNotFoundError => e
+        Legion::Logging.warn "Embedding health check #{provider}/#{model}: model not in RubyLLM registry (#{e.message}) — skipping"
+        false
+      rescue StandardError => e
+        Legion::Logging.warn "Embedding health check failed for #{provider}/#{model}: #{e.class}: #{e.message} — skipping"
+        false
       end
 
       def probe_embedding_provider(provider, ollama_preferred)
@@ -649,19 +677,6 @@ module Legion
                              "#{Discovery::System.available_memory_mb} MB available"
       rescue StandardError => e
         Legion::Logging.warn "Discovery failed: #{e.message}"
-      end
-
-      def ping_provider
-        model = settings[:default_model]
-        provider = settings[:default_provider]
-        return unless model && provider
-
-        start_time = Time.now
-        RubyLLM.chat(model: model, provider: provider).ask('Respond with only the word: pong')
-        elapsed = ((Time.now - start_time) * 1000).round
-        Legion::Logging.info "LLM ping #{provider}/#{model}: pong (#{elapsed}ms)"
-      rescue StandardError => e
-        Legion::Logging.warn "LLM ping failed for #{provider}/#{model}: #{e.message}"
       end
 
       def register_routes

--- a/lib/legion/llm/codex_config_loader.rb
+++ b/lib/legion/llm/codex_config_loader.rb
@@ -19,6 +19,20 @@ module Legion
         apply_codex_config(config)
       end
 
+      def read_token
+        return nil unless File.exist?(CODEX_AUTH)
+
+        config = read_json(CODEX_AUTH)
+        return nil if config.empty?
+        return nil unless config[:auth_mode] == 'chatgpt'
+
+        token = config.dig(:tokens, :access_token)
+        return nil unless token.is_a?(String) && !token.empty?
+        return nil unless token_valid?(token)
+
+        token
+      end
+
       def read_json(path)
         ::JSON.parse(File.read(path), symbolize_names: true)
       rescue StandardError => e

--- a/lib/legion/llm/discovery/ollama.rb
+++ b/lib/legion/llm/discovery/ollama.rb
@@ -18,11 +18,11 @@ module Legion
           end
 
           def model_available?(name)
-            model_names.include?(name)
+            model_names.any? { |n| n == name || n.start_with?("#{name}:") }
           end
 
           def model_size(name)
-            models.find { |m| m['name'] == name }&.dig('size')
+            models.find { |m| m['name'] == name || m['name'].start_with?("#{name}:") }&.dig('size')
           end
 
           def refresh!

--- a/lib/legion/llm/embeddings.rb
+++ b/lib/legion/llm/embeddings.rb
@@ -22,6 +22,9 @@ module Legion
 
           provider ||= resolve_provider
           model    ||= resolve_model(provider)
+
+          return generate_ollama(text: text, model: model) if provider&.to_sym == :ollama
+
           response   = RubyLLM.embed(text, **build_opts(model, provider, dimensions))
           vector     = apply_dimension_enforcement(response.vectors.first, provider)
           return dimension_error(model, provider, vector) if vector.is_a?(String)
@@ -37,7 +40,10 @@ module Legion
 
           provider ||= resolve_provider
           model    ||= resolve_model(provider)
-          response   = RubyLLM.embed(texts, **build_opts(model, provider, dimensions))
+
+          return generate_ollama_batch(texts: texts, model: model) if provider&.to_sym == :ollama
+
+          response = RubyLLM.embed(texts, **build_opts(model, provider, dimensions))
           response.vectors.each_with_index.map do |vec, i|
             build_batch_entry(vec, model, provider, i)
           end
@@ -168,6 +174,37 @@ module Legion
           Legion::Settings.dig(:llm, :embedding) || {}
         rescue StandardError
           {}
+        end
+
+        def generate_ollama(text:, model:)
+          result = ollama_embed_request(model: model, input: text)
+          vector = result['embeddings']&.first
+          vector = apply_dimension_enforcement(vector, :ollama) if vector
+          return dimension_error(model, :ollama, vector) if vector.is_a?(String)
+
+          { vector: vector, model: model, provider: :ollama, dimensions: vector&.size || 0, tokens: 0 }
+        end
+
+        def generate_ollama_batch(texts:, model:)
+          result = ollama_embed_request(model: model, input: texts)
+          vectors = result['embeddings'] || []
+          vectors.each_with_index.map do |vec, i|
+            build_batch_entry(vec, model, :ollama, i)
+          end
+        end
+
+        def ollama_embed_request(model:, input:)
+          base_url = Legion::Settings.dig(:llm, :providers, :ollama, :base_url) || 'http://localhost:11434'
+          conn = Faraday.new(url: base_url) do |f|
+            f.options.timeout = 30
+            f.options.open_timeout = 5
+            f.adapter Faraday.default_adapter
+          end
+          body = { model: model, input: input }
+          response = conn.post('/api/embed', body.to_json, 'Content-Type' => 'application/json')
+          raise "Ollama embed failed: #{response.status} #{response.body}" unless response.success?
+
+          ::JSON.parse(response.body)
         end
       end
     end

--- a/lib/legion/llm/pipeline/executor.rb
+++ b/lib/legion/llm/pipeline/executor.rb
@@ -141,6 +141,42 @@ module Legion
         end
 
         def step_provider_call
+          providers_tried = []
+          begin
+            execute_provider_request
+          rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError,
+                 Faraday::UnauthorizedError, Faraday::ForbiddenError => e
+            providers_tried << @resolved_provider
+            fallback = find_fallback_provider(exclude: providers_tried)
+            if fallback
+              if defined?(Legion::Logging)
+                Legion::Logging.warn "[pipeline] #{@resolved_provider} auth failed (#{e.class}), falling back to #{fallback[:provider]}:#{fallback[:model]}"
+              end
+              @resolved_provider = fallback[:provider]
+              @resolved_model = fallback[:model]
+              @warnings << { type: :provider_fallback, original_error: e.message, fallback: "#{@resolved_provider}:#{@resolved_model}" }
+              @timeline.record(
+                category: :provider, key: 'provider:fallback',
+                direction: :internal,
+                detail: "auth failed on #{providers_tried.last}, trying #{@resolved_provider}",
+                from: 'pipeline', to: "provider:#{@resolved_provider}"
+              )
+              retry
+            end
+            raise Legion::LLM::AuthError, e.message
+          rescue RubyLLM::RateLimitError => e
+            raise Legion::LLM::RateLimitError, e.message
+          rescue RubyLLM::ServerError, RubyLLM::ServiceUnavailableError, RubyLLM::OverloadedError,
+                 Faraday::ServerError => e
+            raise Legion::LLM::ProviderError, e.message
+          rescue Faraday::TooManyRequestsError => e
+            raise Legion::LLM::RateLimitError.new(e.message, retry_after: extract_retry_after(e))
+          rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+            raise Legion::LLM::ProviderDown, e.message
+          end
+        end
+
+        def execute_provider_request
           @timestamps[:provider_start] = Time.now
           @timeline.record(
             category: :provider, key: 'provider:request_sent',
@@ -177,14 +213,6 @@ module Legion
 
           @timestamps[:provider_end] = Time.now
           record_provider_response
-        rescue Faraday::UnauthorizedError, Faraday::ForbiddenError => e
-          raise Legion::LLM::AuthError, e.message
-        rescue Faraday::TooManyRequestsError => e
-          raise Legion::LLM::RateLimitError.new(e.message, retry_after: extract_retry_after(e))
-        rescue Faraday::ServerError => e
-          raise Legion::LLM::ProviderError, e.message
-        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-          raise Legion::LLM::ProviderDown, e.message
         end
 
         def record_provider_response
@@ -220,6 +248,37 @@ module Legion
         end
 
         def step_provider_call_stream(&)
+          providers_tried = []
+          begin
+            execute_provider_request_stream(&)
+          rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError,
+                 Faraday::UnauthorizedError, Faraday::ForbiddenError => e
+            providers_tried << @resolved_provider
+            fallback = find_fallback_provider(exclude: providers_tried)
+            if fallback
+              if defined?(Legion::Logging)
+                Legion::Logging.warn "[pipeline] #{@resolved_provider} stream auth failed (#{e.class}), " \
+                                     "falling back to #{fallback[:provider]}:#{fallback[:model]}"
+              end
+              @resolved_provider = fallback[:provider]
+              @resolved_model = fallback[:model]
+              @warnings << { type: :provider_fallback, original_error: e.message, fallback: "#{@resolved_provider}:#{@resolved_model}" }
+              retry
+            end
+            raise Legion::LLM::AuthError, e.message
+          rescue RubyLLM::RateLimitError => e
+            raise Legion::LLM::RateLimitError, e.message
+          rescue RubyLLM::ServerError, RubyLLM::ServiceUnavailableError, RubyLLM::OverloadedError,
+                 Faraday::ServerError => e
+            raise Legion::LLM::ProviderError, e.message
+          rescue Faraday::TooManyRequestsError => e
+            raise Legion::LLM::RateLimitError.new(e.message, retry_after: extract_retry_after(e))
+          rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+            raise Legion::LLM::ProviderDown, e.message
+          end
+        end
+
+        def execute_provider_request_stream(&)
           @timestamps[:provider_start] = Time.now
           @timeline.record(
             category: :provider, key: 'provider:request_sent',
@@ -243,14 +302,19 @@ module Legion
 
           @timestamps[:provider_end] = Time.now
           record_provider_response
-        rescue Faraday::UnauthorizedError, Faraday::ForbiddenError => e
-          raise Legion::LLM::AuthError, e.message
-        rescue Faraday::TooManyRequestsError => e
-          raise Legion::LLM::RateLimitError.new(e.message, retry_after: extract_retry_after(e))
-        rescue Faraday::ServerError => e
-          raise Legion::LLM::ProviderError, e.message
-        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-          raise Legion::LLM::ProviderDown, e.message
+        end
+
+        def find_fallback_provider(exclude: [])
+          providers = Legion::LLM.settings[:providers] || {}
+          providers.each do |name, config|
+            next unless config.is_a?(Hash) && config[:enabled]
+            next if exclude.include?(name) || exclude.include?(name.to_s)
+            next if name == :ollama
+            next unless config[:default_model]
+
+            return { provider: name, model: config[:default_model] }
+          end
+          nil
         end
 
         def step_response_normalization; end

--- a/lib/legion/llm/providers.rb
+++ b/lib/legion/llm/providers.rb
@@ -134,6 +134,64 @@ module Legion
         end
         Legion::Logging.info "Configured Ollama provider (#{config[:base_url]})"
       end
+
+      SAAS_PROVIDERS = %i[bedrock anthropic openai gemini azure].freeze
+
+      def verify_providers
+        settings[:providers].each do |provider, config|
+          next unless config[:enabled]
+          next unless SAAS_PROVIDERS.include?(provider)
+
+          model = config[:default_model]
+          next unless model
+
+          verify_single_provider(provider, model, config)
+        end
+
+        recover_with_alternative_credentials
+
+        enabled = settings[:providers].select { |_, c| c.is_a?(Hash) && c[:enabled] }
+        if enabled.empty?
+          Legion::Logging.error 'No LLM providers available — all providers failed health checks or are disabled. ' \
+                                'LLM features (chat, inference, embeddings) will not work. ' \
+                                'Check API keys, network connectivity, and provider configuration.'
+        else
+          names = enabled.map { |name, c| "#{name}/#{c[:default_model] || 'auto'}" }
+          Legion::Logging.info "LLM providers available: #{names.join(', ')}"
+        end
+      end
+
+      def recover_with_alternative_credentials
+        recover_openai_with_codex
+      end
+
+      def recover_openai_with_codex
+        openai_config = settings.dig(:providers, :openai)
+        return unless openai_config.is_a?(Hash) && !openai_config[:enabled]
+
+        token = CodexConfigLoader.read_token
+        return unless token
+
+        Legion::Logging.info 'OpenAI disabled — trying Codex auth token as fallback'
+        openai_config[:api_key] = token
+        configure_openai(openai_config)
+        openai_config[:enabled] = true
+        verify_single_provider(:openai, openai_config[:default_model], openai_config)
+      rescue StandardError => e
+        Legion::Logging.debug "Codex credential recovery failed: #{e.message}" if defined?(Legion::Logging)
+      end
+
+      def verify_single_provider(provider, model, config)
+        start_time = Time.now
+        RubyLLM.chat(model: model, provider: provider).ask('Respond with only the word: pong')
+        elapsed = ((Time.now - start_time) * 1000).round
+        Legion::Logging.info "Health check #{provider}/#{model}: OK (#{elapsed}ms)"
+      rescue RubyLLM::ModelNotFoundError => e
+        Legion::Logging.warn "Health check #{provider}/#{model}: model not in RubyLLM registry (#{e.message}) — provider stays enabled"
+      rescue StandardError => e
+        Legion::Logging.warn "Health check failed for #{provider}/#{model}: #{e.class}: #{e.message} — disabling provider"
+        config[:enabled] = false
+      end
     end
   end
 end

--- a/lib/legion/llm/settings.rb
+++ b/lib/legion/llm/settings.rb
@@ -150,7 +150,7 @@ module Legion
             bedrock: 'amazon.titan-embed-text-v2:0',
             openai:  'text-embedding-3-small'
           },
-          ollama_preferred:  %w[mxbai-embed-large bge-large snowflake-arctic-embed]
+          ollama_preferred:  %w[nomic-embed-text mxbai-embed-large bge-large snowflake-arctic-embed]
         }
       end
 
@@ -158,7 +158,7 @@ module Legion
         {
           bedrock:   {
             enabled:       false,
-            default_model: 'us.anthropic.claude-sonnet-4-6-v1',
+            default_model: 'us.anthropic.claude-sonnet-4-6',
             api_key:       nil,
             secret_key:    nil,
             session_token: nil,
@@ -189,7 +189,7 @@ module Legion
           },
           ollama:    {
             enabled:       false,
-            default_model: 'llama3',
+            default_model: 'qwen3.5:latest',
             base_url:      'http://localhost:11434'
           }
         }

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.5.20'
+    VERSION = '0.5.21'
   end
 end

--- a/spec/legion/llm/discovery/settings_spec.rb
+++ b/spec/legion/llm/discovery/settings_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe 'Embedding settings defaults' do
 
     it 'includes ollama preferred models' do
       preferred = Legion::Settings[:llm][:embedding][:ollama_preferred]
-      expect(preferred).to include('mxbai-embed-large')
-      expect(preferred.size).to eq(3)
+      expect(preferred).to include('nomic-embed-text', 'mxbai-embed-large')
+      expect(preferred.size).to eq(4)
     end
   end
 end

--- a/spec/legion/llm/embeddings_spec.rb
+++ b/spec/legion/llm/embeddings_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe '.detect_embedding_capability' do
       allow(Legion::LLM::Discovery::Ollama).to receive(:model_available?)
         .and_return(false)
       Legion::Settings[:llm][:providers][:bedrock][:enabled] = true
+      allow(Legion::LLM).to receive(:verify_embedding).and_return(true)
     end
 
     it 'falls back to bedrock' do
@@ -102,8 +103,8 @@ RSpec.describe 'Legion::LLM::Embeddings' do
     before do
       allow(RubyLLM).to receive(:embed).and_return(mock_response)
       Legion::LLM.instance_variable_set(:@started, true)
-      Legion::LLM.instance_variable_set(:@embedding_provider, :ollama)
-      Legion::LLM.instance_variable_set(:@embedding_model, 'mxbai-embed-large')
+      Legion::LLM.instance_variable_set(:@embedding_provider, :openai)
+      Legion::LLM.instance_variable_set(:@embedding_model, 'text-embedding-3-small')
     end
 
     it 'returns exactly 1024 dimensions' do
@@ -152,13 +153,13 @@ RSpec.describe 'Legion::LLM::Embeddings' do
   describe '.generate with cached provider' do
     before do
       Legion::LLM.instance_variable_set(:@started, true)
-      Legion::LLM.instance_variable_set(:@embedding_provider, :ollama)
-      Legion::LLM.instance_variable_set(:@embedding_model, 'mxbai-embed-large')
+      Legion::LLM.instance_variable_set(:@embedding_provider, :openai)
+      Legion::LLM.instance_variable_set(:@embedding_model, 'text-embedding-3-small')
     end
 
     it 'uses cached provider when no explicit provider given' do
       expect(RubyLLM).to receive(:embed).with('test', hash_including(
-                                                        model: 'mxbai-embed-large', provider: :ollama
+                                                        model: 'text-embedding-3-small', provider: :openai
                                                       )).and_return(double(vectors: [Array.new(1024, 0.1)], input_tokens: 5))
 
       Legion::LLM::Embeddings.generate(text: 'test')

--- a/spec/legion/llm_spec.rb
+++ b/spec/legion/llm_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Legion::LLM do
   describe '.start and .shutdown' do
     before do
       Legion::Settings[:llm][:providers][:ollama][:enabled] = true
-      allow(described_class).to receive(:ping_provider)
+      allow(described_class).to receive(:verify_providers)
+      allow(described_class).to receive(:verify_embedding).and_return(false)
       stub_request(:get, 'http://localhost:11434/api/tags')
         .to_return(status: 200, body: { 'models' => [] }.to_json)
       allow(Legion::LLM::Discovery::System).to receive(:platform).and_return(:unknown)
@@ -92,7 +93,8 @@ RSpec.describe Legion::LLM do
 
   describe 'auto_configure_defaults' do
     before do
-      allow(described_class).to receive(:ping_provider)
+      allow(described_class).to receive(:verify_providers)
+      allow(described_class).to receive(:verify_embedding).and_return(false)
       allow(described_class).to receive(:ollama_running?).and_return(false)
       allow(Legion::LLM::ClaudeConfigLoader).to receive(:load)
       # Clear any env-var-seeded defaults so auto_configure_defaults actually runs


### PR DESCRIPTION
## Summary
- Ping each SaaS provider at boot and disable failures (bad keys, rate limits, billing)
- Resolve `env://` URIs in LLM settings before provider configuration (fixes late-loaded settings)
- Recover OpenAI with `~/.codex/auth.json` token when env var key fails health check
- Direct Ollama embedding via `POST /api/embed` bypassing broken RubyLLM Ollama support
- Pipeline executor catches `RubyLLM::Error` subclasses and automatically falls back to next enabled provider

## Changes
- **providers.rb**: `verify_providers`, `verify_single_provider`, `recover_with_alternative_credentials`, provider summary log, all-down error log
- **llm.rb**: `resolve_llm_secrets`, `verify_embedding` (skips Ollama — model-pulled check sufficient), removed redundant `ping_provider`
- **settings.rb**: bedrock model `us.anthropic.claude-sonnet-4-6` (was -v1), ollama default `qwen3.5:latest` (was llama3), `nomic-embed-text` added to ollama_preferred
- **executor.rb**: `RubyLLM::ForbiddenError`/`UnauthorizedError` rescue with `find_fallback_provider` retry, merged duplicate Faraday rescue branches
- **discovery/ollama.rb**: `model_available?` prefix matching (`mxbai-embed-large` matches `mxbai-embed-large:latest`)
- **embeddings.rb**: direct `ollama_embed_request` via Faraday to `/api/embed` for single and batch
- **codex_config_loader.rb**: `read_token` class method for credential recovery

## Test plan
- [x] 1069 specs passing, 0 failures
- [x] 0 rubocop offenses
- [x] Tested in Homebrew Cellar — boot logs show correct provider enable/disable, embedding detection, and fallback behavior