### PR TITLE
accept caller and conversation_id in inference endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.5.24] - 2026-03-31
+
+### Added
+- `DaemonClient.inference` accepts optional `caller:` and `conversation_id:` kwargs, forwarded in POST body
+- `/api/llm/inference` route accepts `caller` and `conversation_id` from POST body, forwards to `Legion::LLM.chat`
+
 ## [0.5.23] - 2026-03-31
 
 ### Added

--- a/lib/legion/llm/daemon_client.rb
+++ b/lib/legion/llm/daemon_client.rb
@@ -105,10 +105,13 @@ module Legion
       # POSTs a conversation-level inference request to the daemon REST API.
       # Accepts a full messages array and optional tool schemas.
       # Returns a status hash with structured inference fields on success.
-      def inference(messages:, tools: [], model: nil, provider: nil, timeout: 120)
+      def inference(messages:, tools: [], model: nil, provider: nil, caller: nil, conversation_id: nil,
+                    timeout: 120)
         body = { messages: messages, tools: tools }
-        body[:model]    = model    if model
-        body[:provider] = provider if provider
+        body[:model]           = model           if model
+        body[:provider]        = provider        if provider
+        body[:caller]          = caller          if caller
+        body[:conversation_id] = conversation_id if conversation_id
 
         response = http_post('/api/llm/inference', body, timeout: timeout)
         interpret_inference_response(response)

--- a/lib/legion/llm/routes.rb
+++ b/lib/legion/llm/routes.rb
@@ -289,10 +289,12 @@ module Legion
           body = parse_request_body
           validate_required!(body, :messages)
 
-          messages = body[:messages]
-          raw_tools = body[:tools]
-          model    = body[:model]
-          provider = body[:provider]
+          messages        = body[:messages]
+          raw_tools       = body[:tools]
+          model           = body[:model]
+          provider        = body[:provider]
+          caller_context  = body[:caller]
+          conversation_id = body[:conversation_id]
 
           unless messages.is_a?(Array)
             halt 400, { 'Content-Type' => 'application/json' },
@@ -331,13 +333,17 @@ module Legion
             { role: ms[:role].to_s, content: ms[:content].to_s }
           end
 
-          result = Legion::LLM.chat(
+          effective_caller = caller_context || { source: 'api', path: request.path }
+          chat_opts = {
             messages: normalized_messages,
             model:    model,
             provider: provider,
             tools:    tool_declarations,
-            caller:   { source: 'api', path: request.path }
-          )
+            caller:   effective_caller
+          }
+          chat_opts[:conversation_id] = conversation_id if conversation_id
+
+          result = Legion::LLM.chat(**chat_opts)
 
           if result.is_a?(Legion::LLM::Pipeline::Response)
             raw_msg   = result.message

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.5.23'
+    VERSION = '0.5.24'
   end
 end

--- a/spec/legion/llm/daemon_client_spec.rb
+++ b/spec/legion/llm/daemon_client_spec.rb
@@ -660,6 +660,37 @@ RSpec.describe Legion::LLM::DaemonClient do
         described_class.inference(messages: [])
       end
 
+      it 'includes caller and conversation_id when provided' do
+        response = double('Response', code: '200',
+                                      body: ::JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',
+                                                    model: 'x', input_tokens: 1, output_tokens: 1 } }))
+        allow(response).to receive(:[]).and_return(nil)
+        caller_ctx = { requested_by: { identity: 'esity', type: :human } }
+
+        expect(described_class).to receive(:http_post) do |_path, body_hash, **_kwargs|
+          expect(body_hash[:caller]).to eq(caller_ctx)
+          expect(body_hash[:conversation_id]).to eq('conv-123')
+          response
+        end
+
+        described_class.inference(messages: [], caller: caller_ctx, conversation_id: 'conv-123')
+      end
+
+      it 'omits caller and conversation_id when nil' do
+        response = double('Response', code: '200',
+                                      body: ::JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',
+                                                    model: 'x', input_tokens: 1, output_tokens: 1 } }))
+        allow(response).to receive(:[]).and_return(nil)
+
+        expect(described_class).to receive(:http_post) do |_path, body_hash, **_kwargs|
+          expect(body_hash).not_to have_key(:caller)
+          expect(body_hash).not_to have_key(:conversation_id)
+          response
+        end
+
+        described_class.inference(messages: [])
+      end
+
       it 'passes a custom timeout when provided' do
         response = double('Response', code: '200',
                                       body: ::JSON.dump({ data: { content: 'ok', tool_calls: [], stop_reason: 'end_turn',


### PR DESCRIPTION
## Summary
- `DaemonClient.inference` accepts optional `caller:` and `conversation_id:` kwargs, forwarded in POST body
- `/api/llm/inference` route extracts `caller` and `conversation_id` from POST body and passes to `Legion::LLM.chat`

Part of GAIA Connection Completeness Plan 2 (Section 1).

## Test plan
- [x] 1089 specs passing, 0 failures
- [x] Rubocop clean (0 offenses)
- [x] Version bump to 0.5.24