### PR TITLE
read LEGION_PYTHON_VENV env var for venv path override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 - Broker soft consumer in Providers module — tries Identity::Broker before Settings for all provider credentials (Phase 8 Wave 2)
 
+## [0.6.29] - 2026-04-09
+
+### Changed
+- `PythonVenv::VENV_DIR` reads `LEGION_PYTHON_VENV` env var first, falls back to `~/.legionio/python`
+
 ## [0.6.28] - 2026-04-09
 
 ### Added

--- a/lib/legion/llm/tools/interceptors/python_venv.rb
+++ b/lib/legion/llm/tools/interceptors/python_venv.rb
@@ -5,7 +5,7 @@ module Legion
     module Tools
       module Interceptors
         module PythonVenv
-          VENV_DIR = File.expand_path('~/.legionio/python').freeze
+          VENV_DIR = (ENV['LEGION_PYTHON_VENV'] || File.expand_path('~/.legionio/python')).freeze
           PYTHON   = "#{VENV_DIR}/bin/python3".freeze
           PIP      = "#{VENV_DIR}/bin/pip3".freeze
 

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.6.28'
+    VERSION = '0.6.29'
   end
 end


### PR DESCRIPTION
## Summary
- `PythonVenv::VENV_DIR` reads `ENV['LEGION_PYTHON_VENV']` first, falls back to `~/.legionio/python`
- Enables Homebrew Cellar venv path for LLM tool interceptor

## Test plan
- [x] 1682 specs passing, 0 failures