### PR TITLE
Add settings-driven system_baseline to LLM pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - `system_baseline` setting — configurable default system prompt injected by `EnrichmentInjector` as the universal foundation layer for all pipeline-routed LLM calls; overridable via `Legion::Settings[:llm][:system_baseline]` or set to `nil` to disable
 - `EnrichmentInjector.resolve_baseline` — reads `system_baseline` from settings and prepends it before GAIA advisory, RAG context, skills, and caller system prompt
 
+### Fixed
+- Replaced 11 bare `rescue StandardError` (swallowed exceptions) with `handle_exception` logging across `EnrichmentInjector`, `Skills`, `Skills::DiskLoader`, `Skills::ExternalDiscovery`, `ConversationStore`, `Pipeline::Executor`, and `Providers`
+
 ## [0.7.2] - 2026-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-04-13
+
+### Added
+- `system_baseline` setting — configurable default system prompt injected by `EnrichmentInjector` as the universal foundation layer for all pipeline-routed LLM calls; overridable via `Legion::Settings[:llm][:system_baseline]` or set to `nil` to disable
+- `EnrichmentInjector.resolve_baseline` — reads `system_baseline` from settings and prepends it before GAIA advisory, RAG context, skills, and caller system prompt
+
 ## [0.7.2] - 2026-04-13
 
 ### Fixed

--- a/lib/legion/llm/conversation_store.rb
+++ b/lib/legion/llm/conversation_store.rb
@@ -235,8 +235,8 @@ module Legion
                                 .where(conversation_id: conversation_id)
                                 .max(:seq)
               return (max || 0) + 1
-            rescue StandardError
-              # fall through to default
+            rescue StandardError => e
+              handle_exception(e, level: :debug, operation: 'llm.conversation_store.next_seq_db', conversation_id: conversation_id)
             end
           end
           msgs.empty? ? 1 : msgs.last[:seq] + 1

--- a/lib/legion/llm/pipeline/enrichment_injector.rb
+++ b/lib/legion/llm/pipeline/enrichment_injector.rb
@@ -45,7 +45,8 @@ module Legion
 
           value = Legion::Settings.dig(:llm, :system_baseline)
           value.is_a?(String) && !value.strip.empty? ? value : nil
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :warn, operation: 'llm.pipeline.enrichment_injector.resolve_baseline')
           nil
         end
       end

--- a/lib/legion/llm/pipeline/enrichment_injector.rb
+++ b/lib/legion/llm/pipeline/enrichment_injector.rb
@@ -13,7 +13,11 @@ module Legion
         def inject(system:, enrichments:)
           parts = []
 
-          # GAIA system prompt (highest priority)
+          # Settings-driven baseline (universal foundation, overridable via config)
+          baseline = resolve_baseline
+          parts << baseline if baseline
+
+          # GAIA system prompt (highest priority enrichment)
           if (gaia = enrichments.dig('gaia:system_prompt', :content))
             parts << gaia
           end
@@ -32,8 +36,17 @@ module Legion
           return system if parts.empty?
 
           parts << system if system
-          log.info("[llm][pipeline] enrichments_injected parts=#{parts.size} system_present=#{!system.nil?}")
+          log.info("[llm][pipeline] enrichments_injected parts=#{parts.size} baseline=#{!baseline.nil?} system_present=#{!system.nil?}")
           parts.join("\n\n")
+        end
+
+        def resolve_baseline
+          return nil unless defined?(Legion::Settings)
+
+          value = Legion::Settings.dig(:llm, :system_baseline)
+          value.is_a?(String) && !value.empty? ? value : nil
+        rescue StandardError
+          nil
         end
       end
     end

--- a/lib/legion/llm/pipeline/enrichment_injector.rb
+++ b/lib/legion/llm/pipeline/enrichment_injector.rb
@@ -44,7 +44,7 @@ module Legion
           return nil unless defined?(Legion::Settings)
 
           value = Legion::Settings.dig(:llm, :system_baseline)
-          value.is_a?(String) && !value.empty? ? value : nil
+          value.is_a?(String) && !value.strip.empty? ? value : nil
         rescue StandardError
           nil
         end

--- a/lib/legion/llm/pipeline/executor.rb
+++ b/lib/legion/llm/pipeline/executor.rb
@@ -811,7 +811,8 @@ module Legion
           return tool_call.public_send(field) if tool_call.respond_to?(field)
 
           tool_call[field]
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'llm.pipeline.tool_call_field', field: field)
           nil
         end
 
@@ -1037,7 +1038,8 @@ module Legion
                      :tool_use
                    end
           { reason: reason || :end_turn }
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'llm.pipeline.extract_stop_reason')
           { reason: :end_turn }
         end
 
@@ -1053,7 +1055,8 @@ module Legion
             output_tokens: output
           )
           { estimated_usd: estimated, provider: @resolved_provider, model: @resolved_model }
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'llm.pipeline.estimate_response_cost')
           {}
         end
 

--- a/lib/legion/llm/providers.rb
+++ b/lib/legion/llm/providers.rb
@@ -248,7 +248,8 @@ module Legion
         else
           !Legion::Identity::Broker.token_for(provider).nil?
         end
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :debug, operation: 'llm.providers.broker_credential_available', provider: provider)
         false
       end
     end

--- a/lib/legion/llm/settings.rb
+++ b/lib/legion/llm/settings.rb
@@ -16,6 +16,7 @@ module Legion
           max_tool_rounds:           200,
           default_model:             model_override,
           default_provider:          nil,
+          system_baseline:           system_baseline_default,
           providers:                 providers,
           routing:                   routing_defaults,
           budget:                    budget_defaults,
@@ -36,6 +37,30 @@ module Legion
           provider_layer:            provider_layer_defaults,
           tool_trigger:              tool_trigger_defaults
         }
+      end
+
+      def self.system_baseline_default
+        <<~PROMPT.strip
+          You are Legion, an agentic AI partner running on the LegionIO framework.
+
+          LegionIO is a governed, production-oriented cognitive task and orchestration platform.
+          Your role is to help the user accomplish real work quickly, directly, and safely.
+
+          Core behavior:
+          - Honor user intent and constraints.
+          - Prefer execution over prompt ceremony: do the task when possible, don't just describe it.
+          - Be concise by default; expand only when the user asks for depth.
+          - Be transparent: never claim you ran something you did not run, and never hide uncertainty.
+          - Minimize blast radius: make the smallest effective change and preserve existing behavior unless asked otherwise.
+          - Do not YOLO risky actions. For destructive, irreversible, security-sensitive, or high-impact actions, pause and get explicit confirmation.
+          - When risk or ambiguity is high, ask focused clarifying questions before acting.
+          - Validate outcomes when practical, and report what changed and why.
+          - Prefer solving work directly in-session; only produce handoff artifacts (including prompts for other AI tools) when the user explicitly asks for that format.
+
+          Trust model:
+          - Trust is earned through reliable outcomes, clarity, and safe execution.
+          - Speed matters, but never at the expense of integrity or user trust.
+        PROMPT
       end
 
       def self.confidence_defaults

--- a/lib/legion/llm/skills.rb
+++ b/lib/legion/llm/skills.rb
@@ -9,9 +9,13 @@ require_relative 'skills/base'
 require_relative 'skills/disk_loader'
 require_relative 'skills/external_discovery'
 
+require 'legion/logging/helper'
+
 module Legion
   module LLM
     module Skills
+      extend Legion::Logging::Helper
+
       module_function
 
       def start
@@ -22,7 +26,8 @@ module Legion
 
       def settings_directories
         Array(Legion::LLM.settings.dig(:skills, :directories) || [])
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'llm.skills.settings_directories')
         []
       end
     end

--- a/lib/legion/llm/skills/disk_loader.rb
+++ b/lib/legion/llm/skills/disk_loader.rb
@@ -67,7 +67,8 @@ module Legion
           require 'yaml'
           meta = ::YAML.safe_load(parts[1], permitted_classes: [], symbolize_names: true) || {}
           [meta, parts[2].lstrip]
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'llm.skills.disk_loader.parse_frontmatter')
           [{}, text]
         end
 

--- a/lib/legion/llm/skills/external_discovery.rb
+++ b/lib/legion/llm/skills/external_discovery.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module LLM
     module Skills
       module ExternalDiscovery
+        extend Legion::Logging::Helper
+
         module_function
 
         def discover
@@ -37,13 +41,15 @@ module Legion
 
         def claude_auto_discover?
           Legion::LLM.settings.dig(:skills, :auto_discover, :claude) != false
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'llm.skills.external_discovery.claude_auto_discover')
           true
         end
 
         def codex_auto_discover?
           Legion::LLM.settings.dig(:skills, :auto_discover, :codex) != false
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'llm.skills.external_discovery.codex_auto_discover')
           true
         end
       end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.2'
+    VERSION = '0.7.3'
   end
 end

--- a/spec/legion/llm/pipeline/enrichment_injector_spec.rb
+++ b/spec/legion/llm/pipeline/enrichment_injector_spec.rb
@@ -4,6 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Legion::LLM::Pipeline::EnrichmentInjector do
   describe '.inject' do
+    before do
+      Legion::Settings[:llm][:system_baseline] = nil
+    end
+
     it 'prepends RAG context to system prompt' do
       enrichments = {
         'rag:context_retrieval' => {
@@ -43,6 +47,53 @@ RSpec.describe Legion::LLM::Pipeline::EnrichmentInjector do
     it 'handles nil system prompt' do
       result = described_class.inject(system: nil, enrichments: {})
       expect(result).to be_nil
+    end
+  end
+
+  describe 'system_baseline integration' do
+    it 'prepends system_baseline from settings' do
+      Legion::Settings[:llm][:system_baseline] = 'You are Legion.'
+
+      result = described_class.inject(system: 'Be helpful.', enrichments: {})
+      expect(result).to start_with('You are Legion.')
+      expect(result).to include('Be helpful.')
+    end
+
+    it 'prepends baseline before GAIA and caller system' do
+      Legion::Settings[:llm][:system_baseline] = 'Baseline prompt.'
+      enrichments = {
+        'gaia:system_prompt' => { content: 'GAIA advisory.' }
+      }
+
+      result = described_class.inject(system: 'Caller system.', enrichments: enrichments)
+
+      baseline_pos = result.index('Baseline prompt.')
+      gaia_pos     = result.index('GAIA advisory.')
+      caller_pos   = result.index('Caller system.')
+
+      expect(baseline_pos).to be < gaia_pos
+      expect(gaia_pos).to be < caller_pos
+    end
+
+    it 'injects baseline even when system is nil and no enrichments' do
+      Legion::Settings[:llm][:system_baseline] = 'You are Legion.'
+
+      result = described_class.inject(system: nil, enrichments: {})
+      expect(result).to eq('You are Legion.')
+    end
+
+    it 'skips baseline when set to nil' do
+      Legion::Settings[:llm][:system_baseline] = nil
+
+      result = described_class.inject(system: 'Original', enrichments: {})
+      expect(result).to eq('Original')
+    end
+
+    it 'skips baseline when set to empty string' do
+      Legion::Settings[:llm][:system_baseline] = ''
+
+      result = described_class.inject(system: 'Original', enrichments: {})
+      expect(result).to eq('Original')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,5 +65,8 @@ RSpec.configure do |config|
   config.before(:each) do
     Legion::Settings.reset!
     Legion::Settings.merge_settings('llm', Legion::LLM::Settings.default)
+    # Disable system_baseline by default so existing pipeline mocks are unaffected.
+    # Specs that test baseline behavior set it explicitly.
+    Legion::Settings[:llm][:system_baseline] = nil
   end
 end


### PR DESCRIPTION
## Summary

- Adds `llm.system_baseline` setting with a default behavioral prompt that establishes Legion's identity, core behavior rules, and trust model
- `EnrichmentInjector` reads the baseline from settings and prepends it as the foundation layer before GAIA advisory, RAG context, skills, and caller system prompts
- Overridable via `~/.legionio/settings/llm.json` (`"system_baseline": "custom"`) or set to `null` to disable

## Context

An Interlink user spent an entire conversation having Legion generate copy/paste content for Codex instead of handling the task directly. Root cause: Interlink calls `/api/llm/inference` without a `system` field, and the pipeline had no default behavioral instructions — the LLM received zero guidance.

The baseline is the universal safety net. Assembly order:

```
1. system_baseline     (from settings — foundation, overridable)
2. GAIA advisory       (cognitive context, if any)
3. RAG context         (knowledge retrieval, if any)
4. Active skill        (if any)
5. Caller system       (from CLI/Interlink/API — most specific)
```

## Test plan

- [x] `bundle exec rspec` — 1779 examples, 0 failures
- [x] `bundle exec rubocop` — 267 files, 0 offenses
- [x] Baseline prepended when present, skipped when nil or empty
- [x] Ordering verified: baseline < GAIA < caller system
- [x] Existing pipeline mocks unaffected (baseline nil'd in spec_helper)