### PR TITLE
Fleet WS-00B: fix LLM classification hard gate (PHI/PII → local)

### DIFF
--- a/lib/legion/llm/pipeline/steps/tier_assigner.rb
+++ b/lib/legion/llm/pipeline/steps/tier_assigner.rb
@@ -36,10 +36,11 @@ module Legion
             mapping = find_role_mapping(caller)
             return mapping if mapping
 
-            # 3. Classification-driven
-            if classification && (classification[:contains_phi] || classification[:contains_pii])
-              log.info('[llm][routing] tier_assigned source=classification tier=cloud')
-              return { tier: :cloud, intent: { capability: :reasoning }, source: :classification }
+            # 3. Classification-driven: PHI/PII/restricted -> local only (fail closed)
+            if classification && (classification[:contains_phi] || classification[:contains_pii] ||
+                                  classification[:level]&.to_sym == :restricted)
+              log.info('[llm][routing] tier_assigned source=classification tier=local (phi/pii/restricted)')
+              return { tier: :local, intent: { privacy: :strict }, source: :classification }
             end
 
             # 4. Priority-driven

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.3'
+    VERSION = '0.7.4'
   end
 end

--- a/spec/legion/llm/pipeline/steps/tier_assigner_spec.rb
+++ b/spec/legion/llm/pipeline/steps/tier_assigner_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe Legion::LLM::Pipeline::Steps::TierAssigner do
       end
     end
 
-    context 'classification-driven tier assignment' do
-      it 'routes to cloud when classification contains PHI' do
+    context 'classification-driven tier assignment (PHI/PII hard gate — fail closed)' do
+      it 'constrains PHI to local tier, never cloud' do
         classification = { contains_phi: true, contains_pii: false }
         result = assigner.assign(
           caller:          nil,
@@ -187,12 +187,13 @@ RSpec.describe Legion::LLM::Pipeline::Steps::TierAssigner do
           existing_tier:   nil,
           existing_intent: nil
         )
-        expect(result[:tier]).to eq(:cloud)
-        expect(result[:intent]).to include(capability: :reasoning)
+        expect(result[:tier]).to eq(:local)
+        expect(result[:tier]).not_to eq(:cloud)
+        expect(result[:intent]).to include(privacy: :strict)
         expect(result[:source]).to eq(:classification)
       end
 
-      it 'routes to cloud when classification contains PII' do
+      it 'constrains PII to local tier, never cloud' do
         classification = { contains_phi: false, contains_pii: true }
         result = assigner.assign(
           caller:          nil,
@@ -202,12 +203,26 @@ RSpec.describe Legion::LLM::Pipeline::Steps::TierAssigner do
           existing_tier:   nil,
           existing_intent: nil
         )
-        expect(result[:tier]).to eq(:cloud)
+        expect(result[:tier]).to eq(:local)
+        expect(result[:tier]).not_to eq(:cloud)
         expect(result[:source]).to eq(:classification)
       end
 
-      it 'does not override when neither PHI nor PII' do
-        classification = { contains_phi: false, contains_pii: false }
+      it 'constrains restricted classification level to local tier' do
+        result = assigner.assign(
+          caller:          nil,
+          classification:  { level: :restricted },
+          priority:        :normal,
+          gaia_hint:       nil,
+          existing_tier:   nil,
+          existing_intent: nil
+        )
+        expect(result[:tier]).to eq(:local)
+        expect(result[:source]).to eq(:classification)
+      end
+
+      it 'returns nil when classification is normal (no PHI/PII/restricted)' do
+        classification = { contains_phi: false, contains_pii: false, level: :normal }
         result = assigner.assign(
           caller:          nil,
           classification:  classification,
@@ -317,7 +332,7 @@ RSpec.describe Legion::LLM::Pipeline::Steps::TierAssigner do
         expect(result[:tier]).to eq(:local)
       end
 
-      it 'prefers classification over priority' do
+      it 'prefers classification over priority (PHI overrides low priority → local)' do
         classification = { contains_phi: true, contains_pii: false }
         result = assigner.assign(
           caller:          nil,
@@ -328,7 +343,7 @@ RSpec.describe Legion::LLM::Pipeline::Steps::TierAssigner do
           existing_intent: nil
         )
         expect(result[:source]).to eq(:classification)
-        expect(result[:tier]).to eq(:cloud)
+        expect(result[:tier]).to eq(:local)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Fixes `TierAssigner` which was routing `contains_phi: true` and `contains_pii: true` to `:cloud` tier — the exact opposite of the required behavior
- PHI/PII data must never leave local/fleet infrastructure; the router now fails closed: PHI, PII, or `:restricted` classification level → `tier: :local, intent: { privacy: :strict }`
- Also adds `:restricted` classification level as a third hard-gate condition (was missing entirely)

## Changes

- `lib/legion/llm/pipeline/steps/tier_assigner.rb`: Replace cloud-routing classification block with local-only fail-closed gate
- `spec/legion/llm/pipeline/steps/tier_assigner_spec.rb`: Replace specs that encoded the wrong (cloud) behavior; add coverage for `:restricted` level and the explicit `not_to eq(:cloud)` assertion

## Test plan

- [x] `bundle exec rspec spec/legion/llm/pipeline/steps/tier_assigner_spec.rb` — 30 examples, 0 failures
- [x] `bundle exec rspec spec/legion/llm/pipeline/` — 468 examples, 10 failures (all 10 are pre-existing on main, none introduced)
- [x] `bundle exec rubocop lib/legion/llm/pipeline/steps/tier_assigner.rb spec/legion/llm/pipeline/steps/tier_assigner_spec.rb` — 0 offenses