### PR TITLE
Fleet WS-00D: add Legion::LLM::Prompt module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-04-14
+
+### Added
+- `Legion::LLM::Prompt` module — clean API replacing `chat`/`ask`/`chat_direct` surface
+  - `Prompt.dispatch(message, intent:, exclude:, tier:, tools:, ...)` — auto-routed via Router
+  - `Prompt.request(message, provider:, model:, ...)` — pinned dispatch, full pipeline
+  - `Prompt.summarize`, `Prompt.extract`, `Prompt.decide` — convenience methods (default `tools: []`)
+  - Nil provider/model guard raises `LLMError` with actionable message
+  - In-process pipeline execution (no DaemonClient HTTP roundtrip)
+  - Backward compat: `Legion::LLM.chat` delegates to `Prompt.dispatch` for non-streaming calls
+- `build_pipeline_request` uses `Pipeline::Request.from_chat_args` as base, preserving all pipeline kwargs
+
+## [0.7.4] - 2026-04-14
+
+### Fixed
+- PHI/PII classification hard gate: `TierAssigner` now routes `contains_phi`/`contains_pii`/`:restricted` to `tier: :local` (fail closed). Previously routed to `:cloud`.
+
 ## [0.7.3] - 2026-04-13
 
 ### Added

--- a/lib/legion/llm.rb
+++ b/lib/legion/llm.rb
@@ -547,7 +547,7 @@ module Legion
         if pipeline_enabled? && (message || kwargs[:messages]) && !block_given?
           return Prompt.dispatch(
             message || kwargs[:messages],
-            intent: intent, provider: provider, model: model,
+            intent: intent, tier: tier, provider: provider, model: model,
             escalate: escalate, max_escalations: max_escalations,
             quality_check: quality_check, **kwargs.except(:messages)
           )

--- a/lib/legion/llm.rb
+++ b/lib/legion/llm.rb
@@ -37,6 +37,7 @@ require_relative 'llm/cost_tracker'
 require_relative 'llm/token_tracker'
 require_relative 'llm/override_confidence'
 require_relative 'llm/routes'
+require_relative 'llm/prompt'
 
 begin
   require_relative 'llm/skills'
@@ -543,7 +544,17 @@ module Legion
           "tier=#{tier} escalate=#{escalate} max_escalations=#{max_escalations} " \
           "quality_check=#{quality_check} message_present=#{!message.nil?} kwargs=#{kwargs.keys.sort}"
         )
-        if pipeline_enabled? && (message || kwargs[:messages])
+        if pipeline_enabled? && (message || kwargs[:messages]) && !block_given?
+          return Prompt.dispatch(
+            message || kwargs[:messages],
+            intent: intent, provider: provider, model: model,
+            escalate: escalate, max_escalations: max_escalations,
+            quality_check: quality_check, **kwargs.except(:messages)
+          )
+        end
+
+        # Streaming with pipeline — old path (Prompt does not handle streaming yet)
+        if pipeline_enabled? && (message || kwargs[:messages]) && block_given?
           return chat_via_pipeline(model: model, provider: provider, intent: intent, tier: tier,
                                    message: message, escalate: escalate, max_escalations: max_escalations,
                                    quality_check: quality_check, **kwargs, &)

--- a/lib/legion/llm/prompt.rb
+++ b/lib/legion/llm/prompt.rb
@@ -10,7 +10,8 @@ module Legion
       # When provider/model are passed explicitly, they take precedence over routing.
       def dispatch(message, # rubocop:disable Metrics/ParameterLists
                    intent: nil,
-                   exclude: {}, # rubocop:disable Lint/UnusedMethodArgument -- consumed by Router in WS-00E
+                   exclude: {},
+                   tier: nil,
                    provider: nil,
                    model: nil,
                    schema: nil,
@@ -29,8 +30,8 @@ module Legion
         resolved_provider = provider
         resolved_model = model
 
-        if resolved_provider.nil? && resolved_model.nil? && intent && defined?(Router) && Router.routing_enabled?
-          resolution = Router.resolve(intent: intent)
+        if resolved_provider.nil? && resolved_model.nil? && defined?(Router) && Router.routing_enabled?
+          resolution = Router.resolve(intent: intent, tier: tier, exclude: exclude)
           resolved_provider = resolution&.provider
           resolved_model = resolution&.model
         end
@@ -41,6 +42,8 @@ module Legion
         request(message,
                 provider:        resolved_provider,
                 model:           resolved_model,
+                intent:          intent,
+                tier:            tier,
                 schema:          schema,
                 tools:           tools,
                 escalate:        escalate,
@@ -60,6 +63,8 @@ module Legion
       def request(message, # rubocop:disable Metrics/ParameterLists
                   provider:,
                   model:,
+                  intent: nil,
+                  tier: nil,
                   schema: nil,
                   tools: nil,
                   escalate: nil,
@@ -79,7 +84,8 @@ module Legion
         end
 
         pipeline_request = build_pipeline_request(
-          message, provider: provider, model: model, schema: schema, tools: tools,
+          message, provider: provider, model: model, intent: intent, tier: tier,
+                   schema: schema, tools: tools,
                    escalate: escalate, max_escalations: max_escalations,
                    thinking: thinking, temperature: temperature, max_tokens: max_tokens,
                    tracing: tracing, agent: agent, caller: caller, cache: cache,
@@ -110,44 +116,72 @@ module Legion
 
       # --- Private helpers ---
 
-      def build_pipeline_request(message, provider:, model:, schema:, tools:, # rubocop:disable Metrics/ParameterLists
+      def build_pipeline_request(message, provider:, model:, intent:, tier:, schema:, tools:, # rubocop:disable Metrics/ParameterLists
                                  escalate:, max_escalations:, thinking:, temperature:,
                                  max_tokens:, tracing:, agent:, caller:, cache:,
                                  quality_check:, **rest)
-        messages = message.is_a?(Array) ? message : [{ role: :user, content: message.to_s }]
+        # Build base request via from_chat_args to preserve full pipeline kwargs
+        # (context_strategy, tool_choice, idempotency_key, ttl, enrichments, predictions, etc.)
+        chat_message = message.is_a?(Array) ? nil : message.to_s
+        chat_messages = message.is_a?(Array) ? message : nil
 
-        generation = {}
+        base = Pipeline::Request.from_chat_args(
+          message:         chat_message,
+          messages:        chat_messages,
+          model:           model,
+          provider:        provider,
+          intent:          intent,
+          tier:            tier,
+          tools:           tools,
+          thinking:        thinking,
+          tracing:         tracing,
+          agent:           agent,
+          caller:          caller,
+          cache:           cache,
+          escalate:        escalate,
+          max_escalations: max_escalations,
+          quality_check:   quality_check,
+          **rest
+        )
+
+        # Overlay Prompt-specific translations on top of the base request
+        generation = (base.generation || {}).dup
         generation[:temperature] = temperature if temperature
 
-        tokens = { max: max_tokens || 4096 }
+        tokens = (base.tokens || {}).dup
+        tokens[:max] = max_tokens if max_tokens
 
         response_format = if schema
                             { type: :json_schema, schema: schema }
+                          elsif base.response_format
+                            base.response_format
                           else
                             { type: :text }
                           end
 
-        extra = { quality_check: quality_check, escalate: escalate, max_escalations: max_escalations }
-        extra.merge!(rest.except(:system, :messages, :conversation_id, :priority, :metadata, :stream))
-
         Pipeline::Request.build(
-          messages:        messages,
-          system:          rest[:system],
-          routing:         { provider: provider, model: model },
-          tools:           tools || [],
-          thinking:        thinking,
-          generation:      generation,
-          tokens:          tokens,
-          response_format: response_format,
-          tracing:         tracing,
-          agent:           agent,
-          caller:          caller,
-          cache:           cache || { strategy: :default, cacheable: true },
-          conversation_id: rest[:conversation_id],
-          priority:        rest[:priority] || :normal,
-          metadata:        rest[:metadata] || {},
-          stream:          rest[:stream] || false,
-          extra:           extra
+          messages:         base.messages,
+          system:           base.system,
+          routing:          base.routing || { provider: provider, model: model },
+          tools:            base.tools || tools || [],
+          thinking:         base.thinking || thinking,
+          generation:       generation,
+          tokens:           tokens,
+          response_format:  response_format,
+          tracing:          base.tracing || tracing,
+          agent:            base.agent || agent,
+          caller:           base.caller || caller,
+          cache:            base.cache || cache || { strategy: :default, cacheable: true },
+          conversation_id:  base.conversation_id,
+          priority:         base.priority || :normal,
+          metadata:         base.metadata || {},
+          stream:           base.stream || false,
+          extra:            base.extra || {},
+          context_strategy: base.respond_to?(:context_strategy) ? base.context_strategy : nil,
+          idempotency_key:  base.respond_to?(:idempotency_key) ? base.idempotency_key : nil,
+          ttl:              base.respond_to?(:ttl) ? base.ttl : nil,
+          enrichments:      base.respond_to?(:enrichments) ? base.enrichments : nil,
+          predictions:      base.respond_to?(:predictions) ? base.predictions : nil
         )
       end
 

--- a/lib/legion/llm/prompt.rb
+++ b/lib/legion/llm/prompt.rb
@@ -10,7 +10,7 @@ module Legion
       # When provider/model are passed explicitly, they take precedence over routing.
       def dispatch(message, # rubocop:disable Metrics/ParameterLists
                    intent: nil,
-                   exclude: {},
+                   exclude: {}, # rubocop:disable Lint/UnusedMethodArgument -- forwarded to Router.resolve in WS-00E
                    tier: nil,
                    provider: nil,
                    model: nil,
@@ -31,7 +31,7 @@ module Legion
         resolved_model = model
 
         if resolved_provider.nil? && resolved_model.nil? && defined?(Router) && Router.routing_enabled?
-          resolution = Router.resolve(intent: intent, tier: tier, exclude: exclude)
+          resolution = Router.resolve(intent: intent, tier: tier)
           resolved_provider = resolution&.provider
           resolved_model = resolution&.model
         end
@@ -116,7 +116,7 @@ module Legion
 
       # --- Private helpers ---
 
-      def build_pipeline_request(message, provider:, model:, intent:, tier:, schema:, tools:, # rubocop:disable Metrics/ParameterLists
+      def build_pipeline_request(message, provider:, model:, intent:, tier:, schema:, tools:, # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
                                  escalate:, max_escalations:, thinking:, temperature:,
                                  max_tokens:, tracing:, agent:, caller:, cache:,
                                  quality_check:, **rest)
@@ -164,24 +164,34 @@ module Legion
           system:           base.system,
           routing:          base.routing || { provider: provider, model: model },
           tools:            base.tools || tools || [],
+          tool_choice:      base.tool_choice,
           thinking:         base.thinking || thinking,
           generation:       generation,
           tokens:           tokens,
+          stop:             base.stop,
           response_format:  response_format,
-          tracing:          base.tracing || tracing,
-          agent:            base.agent || agent,
-          caller:           base.caller || caller,
-          cache:            base.cache || cache || { strategy: :default, cacheable: true },
-          conversation_id:  base.conversation_id,
-          priority:         base.priority || :normal,
-          metadata:         base.metadata || {},
           stream:           base.stream || false,
-          extra:            base.extra || {},
-          context_strategy: base.respond_to?(:context_strategy) ? base.context_strategy : nil,
-          idempotency_key:  base.respond_to?(:idempotency_key) ? base.idempotency_key : nil,
-          ttl:              base.respond_to?(:ttl) ? base.ttl : nil,
-          enrichments:      base.respond_to?(:enrichments) ? base.enrichments : nil,
-          predictions:      base.respond_to?(:predictions) ? base.predictions : nil
+          fork:             base.fork,
+          cache:            base.cache || cache || { strategy: :default, cacheable: true },
+          priority:         base.priority || :normal,
+          tracing:          base.tracing || tracing,
+          classification:   base.classification,
+          caller:           base.caller || caller,
+          agent:            base.agent || agent,
+          billing:          base.billing,
+          test:             base.test,
+          modality:         base.modality,
+          hooks:            base.hooks,
+          conversation_id:  base.conversation_id,
+          idempotency_key:  base.idempotency_key,
+          schema_version:   base.schema_version,
+          id:               base.id,
+          ttl:              base.ttl,
+          metadata:         base.metadata || {},
+          enrichments:      base.enrichments || {},
+          predictions:      base.predictions || {},
+          context_strategy: base.context_strategy,
+          extra:            base.extra || {}
         )
       end
 

--- a/lib/legion/llm/prompt.rb
+++ b/lib/legion/llm/prompt.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+module Legion
+  module LLM
+    module Prompt
+      module_function
+
+      # Auto-routed: Router picks the best provider+model based on intent.
+      # Primary entry point for most LLM calls.
+      # When provider/model are passed explicitly, they take precedence over routing.
+      def dispatch(message, # rubocop:disable Metrics/ParameterLists
+                   intent: nil,
+                   exclude: {}, # rubocop:disable Lint/UnusedMethodArgument -- consumed by Router in WS-00E
+                   provider: nil,
+                   model: nil,
+                   schema: nil,
+                   tools: nil,
+                   escalate: nil,
+                   max_escalations: 3,
+                   thinking: nil,
+                   temperature: nil,
+                   max_tokens: nil,
+                   tracing: nil,
+                   agent: nil,
+                   caller: nil,
+                   cache: nil,
+                   quality_check: nil,
+                   **)
+        resolved_provider = provider
+        resolved_model = model
+
+        if resolved_provider.nil? && resolved_model.nil? && intent && defined?(Router) && Router.routing_enabled?
+          resolution = Router.resolve(intent: intent)
+          resolved_provider = resolution&.provider
+          resolved_model = resolution&.model
+        end
+
+        resolved_provider ||= Legion::LLM.settings[:default_provider]
+        resolved_model ||= Legion::LLM.settings[:default_model]
+
+        request(message,
+                provider:        resolved_provider,
+                model:           resolved_model,
+                schema:          schema,
+                tools:           tools,
+                escalate:        escalate,
+                max_escalations: max_escalations,
+                thinking:        thinking,
+                temperature:     temperature,
+                max_tokens:      max_tokens,
+                tracing:         tracing,
+                agent:           agent,
+                caller:          caller,
+                cache:           cache,
+                quality_check:   quality_check,
+                **)
+      end
+
+      # Pinned: caller specifies exact provider+model. Full pipeline runs in-process.
+      def request(message, # rubocop:disable Metrics/ParameterLists
+                  provider:,
+                  model:,
+                  schema: nil,
+                  tools: nil,
+                  escalate: nil,
+                  max_escalations: 3,
+                  thinking: nil,
+                  temperature: nil,
+                  max_tokens: nil,
+                  tracing: nil,
+                  agent: nil,
+                  caller: nil,
+                  cache: nil,
+                  quality_check: nil,
+                  **)
+        if provider.nil? || model.nil?
+          raise LLMError, "Prompt.request: provider and model must be set (got provider=#{provider.inspect}, model=#{model.inspect}). " \
+                          'Configure Legion::Settings[:llm][:default_provider] and [:default_model], or pass them explicitly.'
+        end
+
+        pipeline_request = build_pipeline_request(
+          message, provider: provider, model: model, schema: schema, tools: tools,
+                   escalate: escalate, max_escalations: max_escalations,
+                   thinking: thinking, temperature: temperature, max_tokens: max_tokens,
+                   tracing: tracing, agent: agent, caller: caller, cache: cache,
+                   quality_check: quality_check, **
+        )
+
+        executor = Pipeline::Executor.new(pipeline_request)
+        executor.call
+      end
+
+      # Condense a conversation or feedback history into a shorter form.
+      def summarize(messages, tools: [], **)
+        prompt = build_summarize_prompt(messages)
+        dispatch(prompt, tools: tools, **)
+      end
+
+      # Extract structured data from unstructured text.
+      def extract(text, schema:, tools: [], **)
+        prompt = build_extract_prompt(text)
+        dispatch(prompt, schema: schema, tools: tools, **)
+      end
+
+      # Pick from a set of options with reasoning.
+      def decide(question, options:, tools: [], **)
+        prompt = build_decide_prompt(question, options)
+        dispatch(prompt, tools: tools, **)
+      end
+
+      # --- Private helpers ---
+
+      def build_pipeline_request(message, provider:, model:, schema:, tools:, # rubocop:disable Metrics/ParameterLists
+                                 escalate:, max_escalations:, thinking:, temperature:,
+                                 max_tokens:, tracing:, agent:, caller:, cache:,
+                                 quality_check:, **rest)
+        messages = message.is_a?(Array) ? message : [{ role: :user, content: message.to_s }]
+
+        generation = {}
+        generation[:temperature] = temperature if temperature
+
+        tokens = { max: max_tokens || 4096 }
+
+        response_format = if schema
+                            { type: :json_schema, schema: schema }
+                          else
+                            { type: :text }
+                          end
+
+        extra = { quality_check: quality_check, escalate: escalate, max_escalations: max_escalations }
+        extra.merge!(rest.except(:system, :messages, :conversation_id, :priority, :metadata, :stream))
+
+        Pipeline::Request.build(
+          messages:        messages,
+          system:          rest[:system],
+          routing:         { provider: provider, model: model },
+          tools:           tools || [],
+          thinking:        thinking,
+          generation:      generation,
+          tokens:          tokens,
+          response_format: response_format,
+          tracing:         tracing,
+          agent:           agent,
+          caller:          caller,
+          cache:           cache || { strategy: :default, cacheable: true },
+          conversation_id: rest[:conversation_id],
+          priority:        rest[:priority] || :normal,
+          metadata:        rest[:metadata] || {},
+          stream:          rest[:stream] || false,
+          extra:           extra
+        )
+      end
+
+      def build_summarize_prompt(messages)
+        text = if messages.is_a?(Array)
+                 messages.map { |m| m.is_a?(Hash) ? m[:content] : m.to_s }.join("\n")
+               else
+                 messages.to_s
+               end
+        "Summarize the following content concisely, preserving key points:\n\n#{text}"
+      end
+
+      def build_extract_prompt(text)
+        "Extract structured data from the following text. Return only the JSON matching the provided schema.\n\n#{text}"
+      end
+
+      def build_decide_prompt(question, options)
+        options_text = options.each_with_index.map { |opt, i| "#{i + 1}. #{opt}" }.join("\n")
+        "#{question}\n\nOptions:\n#{options_text}\n\nPick the best option and explain your reasoning."
+      end
+
+      private_class_method :build_pipeline_request,
+                           :build_summarize_prompt, :build_extract_prompt, :build_decide_prompt
+    end
+  end
+end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.3'
+    VERSION = '0.7.4'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.4'
+    VERSION = '0.7.5'
   end
 end

--- a/spec/legion/llm/prompt_compat_spec.rb
+++ b/spec/legion/llm/prompt_compat_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Legion::LLM backward compatibility via Prompt' do
+  let(:mock_response) do
+    double('Response', content: 'compat response', input_tokens: 10, output_tokens: 5,
+                       tool_calls: nil, stop_reason: :end_turn, model_id: 'test-model')
+  end
+
+  let(:mock_session) do
+    session = double('Chat')
+    allow(session).to receive(:ask).and_return(mock_response)
+    allow(session).to receive(:with_tool)
+    allow(session).to receive(:with_instructions)
+    allow(session).to receive(:add_message)
+    allow(session).to receive(:respond_to?).and_return(false)
+    allow(session).to receive(:respond_to?).with(:on_tool_call).and_return(false)
+    allow(session).to receive(:respond_to?).with(:on_tool_result).and_return(false)
+    session
+  end
+
+  before do
+    Legion::Settings.reset!
+    Legion::Settings.merge_settings('llm', Legion::LLM::Settings.default)
+    Legion::Settings[:llm][:default_provider] = :anthropic
+    Legion::Settings[:llm][:default_model] = 'claude-sonnet-4-6'
+    Legion::Settings[:llm][:pipeline_enabled] = true
+    allow(RubyLLM).to receive(:chat).and_return(mock_session)
+  end
+
+  describe 'Legion::LLM.chat delegates to Prompt.dispatch' do
+    it 'routes through Prompt.dispatch when pipeline_enabled and not streaming' do
+      expect(Legion::LLM::Prompt).to receive(:dispatch).and_call_original
+      Legion::LLM.chat(message: 'Hello from .chat')
+    end
+
+    it 'returns a Pipeline::Response' do
+      result = Legion::LLM.chat(message: 'Hello from .chat')
+      expect(result).to be_a(Legion::LLM::Pipeline::Response)
+    end
+  end
+end

--- a/spec/legion/llm/prompt_spec.rb
+++ b/spec/legion/llm/prompt_spec.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::LLM::Prompt do
+  let(:mock_response) do
+    double('Response', content: 'test response', input_tokens: 10, output_tokens: 5,
+                       tool_calls: nil, stop_reason: :end_turn, model_id: 'test-model')
+  end
+
+  let(:mock_session) do
+    session = double('Chat')
+    allow(session).to receive(:ask).and_return(mock_response)
+    allow(session).to receive(:with_tool)
+    allow(session).to receive(:with_instructions)
+    allow(session).to receive(:add_message)
+    allow(session).to receive(:respond_to?).and_return(false)
+    allow(session).to receive(:respond_to?).with(:on_tool_call).and_return(false)
+    allow(session).to receive(:respond_to?).with(:on_tool_result).and_return(false)
+    session
+  end
+
+  before do
+    Legion::Settings.reset!
+    Legion::Settings.merge_settings('llm', Legion::LLM::Settings.default)
+    Legion::Settings[:llm][:default_provider] = :anthropic
+    Legion::Settings[:llm][:default_model] = 'claude-sonnet-4-6'
+    Legion::Settings[:llm][:pipeline_enabled] = true
+    allow(RubyLLM).to receive(:chat).and_return(mock_session)
+  end
+
+  describe '.dispatch' do
+    context 'when Router returns a resolution' do
+      let(:resolution) do
+        Legion::LLM::Router::Resolution.new(
+          tier: :cloud, provider: :bedrock, model: 'us.anthropic.claude-sonnet-4-6-v1', rule: 'test-rule'
+        )
+      end
+
+      before do
+        allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(true)
+        allow(Legion::LLM::Router).to receive(:resolve).and_return(resolution)
+      end
+
+      it 'uses the resolved provider and model' do
+        result = described_class.dispatch('Hello')
+        expect(result).to be_a(Legion::LLM::Pipeline::Response)
+      end
+
+      it 'passes intent to the Router' do
+        described_class.dispatch('Hello', intent: { capability: :reasoning })
+        expect(Legion::LLM::Router).to have_received(:resolve).with(hash_including(intent: { capability: :reasoning }))
+      end
+    end
+
+    context 'when Router returns nil' do
+      before do
+        allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(true)
+        allow(Legion::LLM::Router).to receive(:resolve).and_return(nil)
+      end
+
+      it 'falls back to default_provider and default_model' do
+        result = described_class.dispatch('Hello')
+        expect(result).to be_a(Legion::LLM::Pipeline::Response)
+        expect(result.routing[:provider]).to eq(:anthropic)
+        expect(result.routing[:model]).to eq('claude-sonnet-4-6')
+      end
+    end
+
+    context 'when Router is not enabled and no defaults exist' do
+      before do
+        allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+        Legion::Settings[:llm][:default_provider] = nil
+        Legion::Settings[:llm][:default_model] = nil
+      end
+
+      it 'raises LLMError when both provider and model are nil' do
+        expect { described_class.dispatch('Hello') }.to raise_error(
+          Legion::LLM::LLMError, /provider and model must be set/
+        )
+      end
+    end
+
+    context 'with exclude parameter' do
+      before do
+        allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+      end
+
+      it 'accepts exclude parameter without error' do
+        result = described_class.dispatch('Hello', exclude: { anthropic: ['claude-sonnet-4-6'] })
+        expect(result).to be_a(Legion::LLM::Pipeline::Response)
+      end
+    end
+
+    context 'with all optional parameters' do
+      it 'accepts the full parameter set' do
+        result = described_class.dispatch(
+          'Hello',
+          intent:          { capability: :reasoning },
+          exclude:         {},
+          schema:          { type: :object },
+          tools:           [],
+          escalate:        false,
+          max_escalations: 3,
+          thinking:        { budget_tokens: 32_000 },
+          temperature:     0.7,
+          max_tokens:      1024,
+          tracing:         { trace_id: 'abc' },
+          agent:           { id: 'fleet:dev' },
+          caller:          { extension: 'lex-test' },
+          cache:           { enabled: true },
+          quality_check:   nil
+        )
+        expect(result).to be_a(Legion::LLM::Pipeline::Response)
+      end
+    end
+  end
+
+  describe '.request' do
+    context 'with valid provider and model' do
+      it 'runs the pipeline in-process and returns a Pipeline::Response' do
+        result = described_class.request('Hello', provider: :anthropic, model: 'claude-sonnet-4-6')
+        expect(result).to be_a(Legion::LLM::Pipeline::Response)
+      end
+
+      it 'includes the provider in the response routing' do
+        result = described_class.request('Hello', provider: :anthropic, model: 'claude-sonnet-4-6')
+        expect(result.routing[:provider]).to eq(:anthropic)
+      end
+
+      it 'includes the model in the response routing' do
+        result = described_class.request('Hello', provider: :anthropic, model: 'claude-sonnet-4-6')
+        expect(result.routing[:model]).to eq('claude-sonnet-4-6')
+      end
+    end
+
+    context 'with nil provider' do
+      it 'raises LLMError' do
+        expect { described_class.request('Hello', provider: nil, model: 'claude-sonnet-4-6') }.to raise_error(
+          Legion::LLM::LLMError, /provider.*must be set/i
+        )
+      end
+    end
+
+    context 'with nil model' do
+      it 'raises LLMError' do
+        expect { described_class.request('Hello', provider: :anthropic, model: nil) }.to raise_error(
+          Legion::LLM::LLMError, /model.*must be set/i
+        )
+      end
+    end
+
+    context 'with schema parameter' do
+      it 'translates schema to response_format on the Pipeline::Request' do
+        executor = instance_double(Legion::LLM::Pipeline::Executor, call: nil)
+        allow(Legion::LLM::Pipeline::Executor).to receive(:new) do |request|
+          expect(request.response_format).to eq({ type: :json_schema, schema: { type: :object } })
+          executor
+        end
+        allow(executor).to receive(:call).and_return(
+          Legion::LLM::Pipeline::Response.build(
+            request_id: 'req_test', conversation_id: 'conv_test',
+            message: { role: :assistant, content: '{}' },
+            routing: { provider: :anthropic, model: 'claude-sonnet-4-6' }
+          )
+        )
+        described_class.request('Extract data', provider: :anthropic, model: 'claude-sonnet-4-6',
+                                                schema: { type: :object })
+      end
+    end
+
+    context 'with temperature parameter' do
+      it 'translates temperature into generation hash' do
+        executor = instance_double(Legion::LLM::Pipeline::Executor, call: nil)
+        allow(Legion::LLM::Pipeline::Executor).to receive(:new) do |request|
+          expect(request.generation[:temperature]).to eq(0.7)
+          executor
+        end
+        allow(executor).to receive(:call).and_return(
+          Legion::LLM::Pipeline::Response.build(
+            request_id: 'req_test', conversation_id: 'conv_test',
+            message: { role: :assistant, content: 'hi' },
+            routing: { provider: :anthropic, model: 'claude-sonnet-4-6' }
+          )
+        )
+        described_class.request('Hello', provider: :anthropic, model: 'claude-sonnet-4-6', temperature: 0.7)
+      end
+    end
+
+    context 'with max_tokens parameter' do
+      it 'translates max_tokens into tokens hash' do
+        executor = instance_double(Legion::LLM::Pipeline::Executor, call: nil)
+        allow(Legion::LLM::Pipeline::Executor).to receive(:new) do |request|
+          expect(request.tokens[:max]).to eq(2048)
+          executor
+        end
+        allow(executor).to receive(:call).and_return(
+          Legion::LLM::Pipeline::Response.build(
+            request_id: 'req_test', conversation_id: 'conv_test',
+            message: { role: :assistant, content: 'hi' },
+            routing: { provider: :anthropic, model: 'claude-sonnet-4-6' }
+          )
+        )
+        described_class.request('Hello', provider: :anthropic, model: 'claude-sonnet-4-6', max_tokens: 2048)
+      end
+    end
+
+    it 'does NOT call DaemonClient' do
+      expect(Legion::LLM::DaemonClient).not_to receive(:available?)
+      expect(Legion::LLM::DaemonClient).not_to receive(:chat)
+      described_class.request('Hello', provider: :anthropic, model: 'claude-sonnet-4-6')
+    end
+  end
+
+  describe '.summarize' do
+    it 'delegates to dispatch' do
+      allow(described_class).to receive(:dispatch).and_call_original
+      described_class.summarize('Long text to summarize')
+      expect(described_class).to have_received(:dispatch).with(kind_of(String), hash_including(tools: []))
+    end
+
+    it 'defaults tools to empty array' do
+      allow(described_class).to receive(:dispatch).and_call_original
+      described_class.summarize('Text')
+      expect(described_class).to have_received(:dispatch).with(anything, hash_including(tools: []))
+    end
+
+    it 'allows tools override' do
+      tool = double('tool')
+      allow(described_class).to receive(:dispatch).and_call_original
+      described_class.summarize('Text', tools: [tool])
+      expect(described_class).to have_received(:dispatch).with(anything, hash_including(tools: [tool]))
+    end
+
+    it 'returns a Pipeline::Response' do
+      result = described_class.summarize('Some long text to summarize')
+      expect(result).to be_a(Legion::LLM::Pipeline::Response)
+    end
+  end
+
+  describe '.extract' do
+    let(:schema) { { type: :object, properties: { name: { type: :string } } } }
+
+    it 'delegates to dispatch with schema' do
+      allow(described_class).to receive(:dispatch).and_call_original
+      described_class.extract('Raw text', schema: schema)
+      expect(described_class).to have_received(:dispatch).with(
+        kind_of(String), hash_including(schema: schema, tools: [])
+      )
+    end
+
+    it 'defaults tools to empty array' do
+      allow(described_class).to receive(:dispatch).and_call_original
+      described_class.extract('Text', schema: schema)
+      expect(described_class).to have_received(:dispatch).with(anything, hash_including(tools: []))
+    end
+
+    it 'returns a Pipeline::Response' do
+      result = described_class.extract('Some text', schema: schema)
+      expect(result).to be_a(Legion::LLM::Pipeline::Response)
+    end
+  end
+
+  describe '.decide' do
+    let(:options) { %w[Refactor Patch Rewrite] }
+
+    it 'delegates to dispatch' do
+      allow(described_class).to receive(:dispatch).and_call_original
+      described_class.decide('Which approach?', options: options)
+      expect(described_class).to have_received(:dispatch).with(kind_of(String), hash_including(tools: []))
+    end
+
+    it 'defaults tools to empty array' do
+      allow(described_class).to receive(:dispatch).and_call_original
+      described_class.decide('Which?', options: options)
+      expect(described_class).to have_received(:dispatch).with(anything, hash_including(tools: []))
+    end
+
+    it 'returns a Pipeline::Response' do
+      result = described_class.decide('Which approach?', options: options)
+      expect(result).to be_a(Legion::LLM::Pipeline::Response)
+    end
+  end
+end

--- a/spec/legion/llm/prompt_spec.rb
+++ b/spec/legion/llm/prompt_spec.rb
@@ -114,6 +114,42 @@ RSpec.describe Legion::LLM::Prompt do
         expect(result).to be_a(Legion::LLM::Pipeline::Response)
       end
     end
+
+    context 'with real Router.resolve (no stub) — validates call-site keyword compatibility' do
+      before do
+        Legion::Settings[:llm][:routing] = {
+          enabled:        true,
+          default_intent: { privacy: 'normal', capability: 'moderate', cost: 'normal' },
+          rules:          [
+            {
+              name:     'test-cloud-rule',
+              when:     { capability: 'moderate' },
+              then:     { tier: 'cloud', provider: 'anthropic', model: 'claude-sonnet-4-6' },
+              priority: 10
+            }
+          ]
+        }
+        Legion::LLM::Router.reset!
+      end
+
+      after { Legion::LLM::Router.reset! }
+
+      it 'does not raise ArgumentError when calling the real Router.resolve with intent' do
+        result = described_class.dispatch('Hello', intent: { capability: :moderate })
+        expect(result).to be_a(Legion::LLM::Pipeline::Response)
+        expect(result.routing[:provider]).to eq(:anthropic)
+        expect(result.routing[:model]).to eq('claude-sonnet-4-6')
+      end
+
+      it 'does not raise ArgumentError when passing exclude to dispatch with routing enabled' do
+        # exclude: is accepted by dispatch but forwarded to Router only when Router supports it (WS-00E)
+        # This verifies dispatch does not crash when exclude is passed, even if Router ignores it
+        result = described_class.dispatch('Hello',
+                                          intent:  { capability: :moderate },
+                                          exclude: { anthropic: ['claude-sonnet-4-6'] })
+        expect(result).to be_a(Legion::LLM::Pipeline::Response)
+      end
+    end
   end
 
   describe '.request' do

--- a/spec/legion/llm/prompt_spec.rb
+++ b/spec/legion/llm/prompt_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Legion::LLM::Prompt do
 
       it 'passes intent to the Router' do
         described_class.dispatch('Hello', intent: { capability: :reasoning })
-        expect(Legion::LLM::Router).to have_received(:resolve).with(hash_including(intent: { capability: :reasoning }))
+        expect(Legion::LLM::Router).to have_received(:resolve).with(hash_including(intent: { capability: :reasoning })).at_least(:once)
       end
     end
 


### PR DESCRIPTION
## Summary

- Adds `Legion::LLM::Prompt` module with clean two-method API: `dispatch` (auto-routed via Router) and `request` (pinned provider+model, in-process pipeline execution)
- Convenience methods: `.summarize`, `.extract`, `.decide` — all default `tools: []` to suppress MCP injection
- `Legion::LLM.chat` delegates to `Prompt.dispatch` when pipeline is enabled (backward-compat shim)

Nil provider/model guard raises `LLMError` with actionable message. Router nil resolution falls back to `default_provider`/`default_model`. Pipeline runs in-process (not through DaemonClient HTTP).

Design doc: `docs/work/ideas/2026-04-13-llm-prompt-builder.md`

## Test plan

- [x] 25 new specs for Prompt module (dispatch, request, summarize, extract, decide, nil guards, Router fallback, translation layer)
- [x] 2 backward-compat specs verifying `.chat` delegates to `Prompt.dispatch`
- [x] 1806 existing specs pass with 0 failures (full backward compat)
- [x] Rubocop: 0 offenses on all changed files