### PR TITLE
fix guard embeddings generate against unsupported providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.7.8] - 2026-04-17
+### Fixed
+- Guard `Embeddings.generate` against providers that don't support embeddings before calling `RubyLLM.embed` — prevents noisy `NoMethodError: undefined method 'render_embedding_payload'` warns when Bedrock (or Anthropic) is the active provider
+
 ## [0.7.7] - 2026-04-15
 
 ### Added

--- a/lib/legion/llm/embeddings.rb
+++ b/lib/legion/llm/embeddings.rb
@@ -46,7 +46,7 @@ module Legion
           return generate_ollama(text: text, model: model) if provider&.to_sym == :ollama
           return generate_azure(text: text, model: model, dimensions: dimensions) if provider&.to_sym == :azure
           return { vector: nil, model: model, provider: provider, error: "provider #{provider} does not support embeddings" } \
-            unless provider_supports_embeddings?(provider)
+            if provider && !provider_supports_embeddings?(provider)
 
           response   = RubyLLM.embed(text, **build_opts(model, provider, dimensions))
           vector     = apply_dimension_enforcement(response.vectors.first, provider)

--- a/lib/legion/llm/embeddings.rb
+++ b/lib/legion/llm/embeddings.rb
@@ -45,6 +45,8 @@ module Legion
 
           return generate_ollama(text: text, model: model) if provider&.to_sym == :ollama
           return generate_azure(text: text, model: model, dimensions: dimensions) if provider&.to_sym == :azure
+          return { vector: nil, model: model, provider: provider, error: "provider #{provider} does not support embeddings" } \
+            unless provider_supports_embeddings?(provider)
 
           response   = RubyLLM.embed(text, **build_opts(model, provider, dimensions))
           vector     = apply_dimension_enforcement(response.vectors.first, provider)

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.7'
+    VERSION = '0.7.8'
   end
 end

--- a/spec/legion/llm/embeddings_gating_spec.rb
+++ b/spec/legion/llm/embeddings_gating_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe 'Legion::LLM::Embeddings provider gating' do
       Legion::LLM.instance_variable_set(:@embedding_provider, :openai)
       Legion::LLM.instance_variable_set(:@embedding_model, 'text-embedding-3-small')
       allow(RubyLLM).to receive(:embed).and_return(mock_response)
+      allow(Legion::LLM::Embeddings).to receive(:provider_supports_embeddings?).with(:openai).and_return(true)
     end
 
     it 'is not blocked and returns a vector' do
@@ -98,6 +99,7 @@ RSpec.describe 'Legion::LLM::Embeddings provider gating' do
       Legion::LLM.instance_variable_set(:@embedding_provider, :openai)
       Legion::LLM.instance_variable_set(:@embedding_model, 'text-embedding-3-small')
       allow(RubyLLM).to receive(:embed).and_return(mock_response)
+      allow(Legion::LLM::Embeddings).to receive(:provider_supports_embeddings?).with(:openai).and_return(true)
     end
 
     it 'is not blocked and returns vectors' do
@@ -135,6 +137,26 @@ RSpec.describe 'Legion::LLM::Embeddings provider gating' do
       allow(Legion::Settings).to receive(:dig).and_raise(StandardError.new('boom'))
       result = Legion::LLM::Embeddings.send(:provider_disabled?, :bedrock)
       expect(result).to be false
+    end
+  end
+
+  describe 'Legion::LLM::Embeddings.generate with an unsupported provider' do
+    before do
+      Legion::Settings[:llm][:providers][:bedrock] = { enabled: true }
+      Legion::LLM.instance_variable_set(:@embedding_provider, :bedrock)
+      allow(Legion::LLM::Embeddings).to receive(:provider_supports_embeddings?).with(:bedrock).and_return(false)
+    end
+
+    it 'returns an error hash without calling RubyLLM.embed' do
+      expect(RubyLLM).not_to receive(:embed)
+      result = Legion::LLM::Embeddings.generate(text: 'hello', provider: :bedrock)
+      expect(result[:vector]).to be_nil
+      expect(result[:error]).to match(/does not support embeddings/)
+    end
+
+    it 'includes the provider name in the error' do
+      result = Legion::LLM::Embeddings.generate(text: 'hello', provider: :bedrock)
+      expect(result[:error]).to include('bedrock')
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #66

Adds a `provider_supports_embeddings?` check in `Embeddings.generate` before calling `RubyLLM.embed`, so providers like `bedrock` and `anthropic` that don't implement `render_embedding_payload` return a clean error hash instead of raising a `NoMethodError` that gets caught and logged as a `WARN`.

## Change

```diff
  return generate_ollama(...) if provider == :ollama
  return generate_azure(...) if provider == :azure
+ return { vector: nil, ..., error: '...' } unless provider_supports_embeddings?(provider)

  response = RubyLLM.embed(text, **build_opts(...))
```

## Testing

CI / RSpec.