### PR TITLE
fix: web_fetch/web_search in LLM routes (#153, #154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.7.13] - 2026-04-20
+
+### Fixed
+- Classification step now always runs the PII/PHI scan, even on unclassified requests — defaults to `:public` baseline. Configurable via `compliance.default_level` (default: `:public`) and `compliance.classification_scan` (default: `true`). Fixes #70
+
 ## [0.7.12] - 2026-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.7.15] - 2026-04-20
+
+### Added
+- PHI cloud provider gate: `compliance.phi_block_cloud` (default: `false`) blocks restricted-classified requests from cloud providers when enabled. Warns on permit when disabled. Cloud provider list configurable via `compliance.cloud_providers`. Fixes #72
+
 ## [0.7.14] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.7.10] - 2026-04-20
+
+### Fixed
+- `configure_anthropic` now passes `base_url` through to RubyLLM (`anthropic_api_base`) when present, enabling custom API gateways and proxies. Fixes #68
+- `configure_openai` now passes `base_url` through to RubyLLM (`openai_api_base`) when present, for consistency with Anthropic and Ollama providers
+- `configure_gemini` now passes `base_url` through to RubyLLM (`gemini_api_base`) when present, for consistency with Anthropic and Ollama providers
+
 ## [0.7.9] - 2026-04-18
 ### Added
 - Expanded PII/PHI classification to cover 12 HIPAA Safe Harbor identifier patterns (was 3) and 20 PHI keywords (was 11). Partial fix for #73

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.7.9] - 2026-04-18
+### Fixed
+- `web_fetch` client tool now delegates to `Legion::CLI::Chat::WebFetch.fetch` instead of bare `Net::HTTP.get` — gains SSL, redirect following, HTML-to-markdown conversion, and `maxLength` truncation (LegionIO/LegionIO#153)
+- Added `web_search` client tool dispatch via `Legion::CLI::Chat::WebSearch.search` — previously fell through to generic "not executable server-side" error (LegionIO/LegionIO#154)
+
 ## [0.7.8] - 2026-04-17
 ### Fixed
 - Guard `Embeddings.generate` against providers that don't support embeddings before calling `RubyLLM.embed` — prevents noisy `NoMethodError: undefined method 'render_embedding_payload'` warns when Bedrock (or Anthropic) is the active provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [0.7.9] - 2026-04-18
+### Added
+- Expanded PII/PHI classification to cover 12 HIPAA Safe Harbor identifier patterns (was 3) and 20 PHI keywords (was 11). Partial fix for #73
+
 ### Fixed
 - `web_fetch` client tool now delegates to `Legion::CLI::Chat::WebFetch.fetch` instead of bare `Net::HTTP.get` — gains SSL, redirect following, HTML-to-markdown conversion, and `maxLength` truncation (LegionIO/LegionIO#153)
 - Added `web_search` client tool dispatch via `Legion::CLI::Chat::WebSearch.search` — previously fell through to generic "not executable server-side" error (LegionIO/LegionIO#154)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.7.11] - 2026-04-20
+
+### Fixed
+- RAG faithfulness check now logs a warning when RAG context is present but no `Hooks::RagGuard` is registered, instead of silently skipping. Fixes #71
+- RAG faithfulness failure now logs at warn level in addition to appending to pipeline warnings array
+
 ## [0.7.10] - 2026-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.7.12] - 2026-04-20
+
+### Fixed
+- RBAC step now respects `rbac.fail_open` setting (default: `true`) when `Legion::Rbac` is unavailable. Fleet callers are always blocked. Non-fleet callers are permitted with a warning when `fail_open` is true, or blocked with 503 when false. Fixes #69
+
 ## [0.7.11] - 2026-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.7.14] - 2026-04-20
+
+### Added
+- PII/PHI redaction mode: `compliance.redact_pii` (default: `false`) replaces detected patterns with configurable placeholder token before pipeline continues. Placeholder configurable via `compliance.redaction_placeholder` (default: `[REDACTED]`)
+- `compliance.strict_hipaa` setting (default: `false`): when enabled, scans all 12 HIPAA patterns; when disabled, scans only core 3 (SSN, email, phone) for lighter processing. Closes #73
+
 ## [0.7.13] - 2026-04-20
 
 ### Fixed

--- a/lib/legion/llm/pipeline/steps/classification.rb
+++ b/lib/legion/llm/pipeline/steps/classification.rb
@@ -36,9 +36,9 @@ module Legion
           ].freeze
 
           def step_classification
-            return unless @request.classification || compliance_classification_default
+            classification = @request.classification || compliance_classification_default || default_classification
+            return unless classification_enabled?(classification)
 
-            classification  = @request.classification || compliance_classification_default
             declared_level  = classification[:level]
             scan            = scan_content_for_sensitive_data
             effective_level = upgrade_if_needed(declared_level, scan)
@@ -107,6 +107,28 @@ module Legion
             return declared_level if current_idx >= threshold_idx
 
             LEVELS[threshold_idx]
+          end
+
+          def default_classification
+            { level: default_classification_level }
+          end
+
+          def default_classification_level
+            return :public unless defined?(Legion::Settings)
+
+            level = Legion::Settings.dig(:compliance, :default_level)
+            level ? level.to_sym : :public
+          rescue StandardError
+            :public
+          end
+
+          def classification_enabled?(_classification)
+            return true unless defined?(Legion::Settings)
+
+            enabled = Legion::Settings.dig(:compliance, :classification_scan)
+            enabled.nil? || enabled
+          rescue StandardError
+            true
           end
 
           def compliance_classification_default

--- a/lib/legion/llm/pipeline/steps/classification.rb
+++ b/lib/legion/llm/pipeline/steps/classification.rb
@@ -209,17 +209,17 @@ module Legion
 
             if phi_block_cloud?
               raise Legion::LLM::PipelineError.new(
-                "PHI content (level=restricted) cannot be sent to cloud provider #{provider}. " \
+                "Restricted/sensitive content (level=restricted) cannot be sent to cloud provider #{provider}. " \
                 'Set compliance.phi_block_cloud=false to override, or use a local provider.',
                 step: :classification
               )
             end
 
             log.warn(
-              "[classification] PHI content (restricted) routing to cloud provider #{provider} — " \
+              "[classification] Restricted/sensitive content (level=restricted) routing to cloud provider #{provider} — " \
               'compliance.phi_block_cloud is disabled, permitting'
             )
-            @warnings << "PHI content routing to cloud provider #{provider} (phi_block_cloud disabled)"
+            @warnings << "Restricted/sensitive content routing to cloud provider #{provider} (phi_block_cloud disabled)"
           end
 
           def phi_block_cloud?

--- a/lib/legion/llm/pipeline/steps/classification.rb
+++ b/lib/legion/llm/pipeline/steps/classification.rb
@@ -11,10 +11,13 @@ module Legion
 
           LEVELS = %i[public internal confidential restricted].freeze
 
-          PII_PATTERNS = {
-            ssn:            /\b\d{3}-\d{2}-\d{4}\b/,
-            email:          /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
-            phone:          /\b(?:\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/,
+          PII_PATTERNS_CORE = {
+            ssn:   /\b\d{3}-\d{2}-\d{4}\b/,
+            email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
+            phone: /\b(?:\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/
+          }.freeze
+
+          PII_PATTERNS_EXTENDED = {
             ip_address:     /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
             date_of_birth:  %r{\b(?:0[1-9]|1[0-2])[/-](?:0[1-9]|[12]\d|3[01])[/-](?:19|20)\d{2}\b},
             zip_code:       /\b\d{5}(?:-\d{4})?\b/,
@@ -25,6 +28,8 @@ module Legion
             vin:            /\b[A-HJ-NPR-Z0-9]{17}\b/,
             npi_number:     /\b\d{10}\b/
           }.freeze
+
+          PII_PATTERNS = PII_PATTERNS_CORE.merge(PII_PATTERNS_EXTENDED).freeze
 
           PHI_KEYWORDS = %w[
             patient diagnosis medication prescription
@@ -43,6 +48,8 @@ module Legion
             scan            = scan_content_for_sensitive_data
             effective_level = upgrade_if_needed(declared_level, scan)
             upgraded        = effective_level != declared_level
+
+            redact_sensitive_content(scan)
 
             @enrichments['classification:scan'] = {
               declared_level:    declared_level,
@@ -79,8 +86,9 @@ module Legion
           def scan_content_for_sensitive_data
             text     = extract_text_content
             patterns = []
+            active_patterns = strict_hipaa_mode? ? PII_PATTERNS : PII_PATTERNS_CORE
 
-            PII_PATTERNS.each do |name, regex|
+            active_patterns.each do |name, regex|
               patterns << name if text.match?(regex)
             end
 
@@ -88,9 +96,38 @@ module Legion
             patterns << :phi_keyword if phi_found
 
             {
-              contains_pii: patterns.intersect?(PII_PATTERNS.keys),
+              contains_pii: patterns.intersect?(active_patterns.keys),
               contains_phi: phi_found,
               patterns:     patterns
+            }
+          end
+
+          def redact_sensitive_content(scan)
+            return unless redaction_enabled?
+            return unless scan[:contains_pii] || scan[:contains_phi]
+
+            placeholder = redaction_placeholder
+            active_patterns = strict_hipaa_mode? ? PII_PATTERNS : PII_PATTERNS_CORE
+
+            @request.messages.each do |message|
+              next unless message[:content].is_a?(String)
+
+              active_patterns.each_value do |regex|
+                message[:content] = message[:content].gsub(regex, placeholder)
+              end
+
+              next unless scan[:contains_phi]
+
+              PHI_KEYWORDS.each do |kw|
+                message[:content] = message[:content].gsub(/\b#{Regexp.escape(kw)}\b/i, placeholder)
+              end
+            end
+
+            @enrichments['classification:redaction'] = {
+              redacted:          true,
+              patterns_redacted: scan[:patterns],
+              placeholder:       placeholder,
+              timestamp:         Time.now
             }
           end
 
@@ -141,6 +178,26 @@ module Legion
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'llm.pipeline.steps.classification.default')
             nil
+          end
+
+          def redaction_enabled?
+            setting = Legion::Settings.dig(:compliance, :redact_pii)
+            setting == true
+          rescue StandardError
+            false
+          end
+
+          def strict_hipaa_mode?
+            setting = Legion::Settings.dig(:compliance, :strict_hipaa)
+            setting == true
+          rescue StandardError
+            false
+          end
+
+          def redaction_placeholder
+            Legion::Settings.dig(:compliance, :redaction_placeholder) || '[REDACTED]'
+          rescue StandardError
+            '[REDACTED]'
           end
         end
       end

--- a/lib/legion/llm/pipeline/steps/classification.rb
+++ b/lib/legion/llm/pipeline/steps/classification.rb
@@ -12,15 +12,27 @@ module Legion
           LEVELS = %i[public internal confidential restricted].freeze
 
           PII_PATTERNS = {
-            ssn:   /\b\d{3}-\d{2}-\d{4}\b/,
-            email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
-            phone: /\b(?:\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/
+            ssn:            /\b\d{3}-\d{2}-\d{4}\b/,
+            email:          /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
+            phone:          /\b(?:\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/,
+            ip_address:     /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
+            date_of_birth:  %r{\b(?:0[1-9]|1[0-2])[/-](?:0[1-9]|[12]\d|3[01])[/-](?:19|20)\d{2}\b},
+            zip_code:       /\b\d{5}(?:-\d{4})?\b/,
+            mrn:            /\b(?:MRN|mrn)[:\s#]?\s?\d{4,12}\b/,
+            account_number: /\b(?:account|acct)[:\s#]?\s?\d{6,20}\b/i,
+            license_number: /\b[A-Z]\d{3,8}\b/,
+            url:            %r{\bhttps?://[^\s<>"']+}i,
+            vin:            /\b[A-HJ-NPR-Z0-9]{17}\b/,
+            npi_number:     /\b\d{10}\b/
           }.freeze
 
           PHI_KEYWORDS = %w[
             patient diagnosis medication prescription
             dob date-of-birth mrn medical-record
-            npi clinical treatment
+            npi clinical treatment health-plan
+            beneficiary insurance-id group-number
+            lab-result radiology pathology
+            admission discharge procedure
           ].freeze
 
           def step_classification

--- a/lib/legion/llm/pipeline/steps/classification.rb
+++ b/lib/legion/llm/pipeline/steps/classification.rb
@@ -50,6 +50,7 @@ module Legion
             upgraded        = effective_level != declared_level
 
             redact_sensitive_content(scan)
+            enforce_phi_cloud_gate(effective_level)
 
             @enrichments['classification:scan'] = {
               declared_level:    declared_level,
@@ -198,6 +199,53 @@ module Legion
             Legion::Settings.dig(:compliance, :redaction_placeholder) || '[REDACTED]'
           rescue StandardError
             '[REDACTED]'
+          end
+
+          def enforce_phi_cloud_gate(effective_level)
+            return unless effective_level == :restricted
+
+            provider = resolve_current_provider
+            return unless cloud_provider?(provider)
+
+            if phi_block_cloud?
+              raise Legion::LLM::PipelineError.new(
+                "PHI content (level=restricted) cannot be sent to cloud provider #{provider}. " \
+                'Set compliance.phi_block_cloud=false to override, or use a local provider.',
+                step: :classification
+              )
+            end
+
+            log.warn(
+              "[classification] PHI content (restricted) routing to cloud provider #{provider} — " \
+              'compliance.phi_block_cloud is disabled, permitting'
+            )
+            @warnings << "PHI content routing to cloud provider #{provider} (phi_block_cloud disabled)"
+          end
+
+          def phi_block_cloud?
+            setting = Legion::Settings.dig(:compliance, :phi_block_cloud)
+            setting == true
+          rescue StandardError
+            false
+          end
+
+          def cloud_provider?(provider)
+            return false unless provider
+
+            cloud_providers = Legion::Settings.dig(:compliance, :cloud_providers) ||
+                              %i[anthropic openai gemini bedrock azure]
+            cloud_providers.map(&:to_sym).include?(provider.to_sym)
+          rescue StandardError
+            false
+          end
+
+          def resolve_current_provider
+            routing = @request.respond_to?(:routing) ? @request.routing : nil
+            provider = routing[:provider] if routing.is_a?(Hash)
+            provider ||= Legion::Settings.dig(:llm, :default_provider)
+            provider&.to_sym
+          rescue StandardError
+            nil
           end
         end
       end

--- a/lib/legion/llm/pipeline/steps/rag_guard.rb
+++ b/lib/legion/llm/pipeline/steps/rag_guard.rb
@@ -12,7 +12,11 @@ module Legion
           def check_rag_faithfulness
             context = @enrichments.dig('rag:context_retrieval', :data, :entries)
             return unless context&.any?
-            return unless defined?(Hooks::RagGuard)
+
+            unless defined?(Hooks::RagGuard)
+              log.warn('[rag_guard] RAG context present but no Hooks::RagGuard registered — faithfulness check skipped')
+              return
+            end
 
             response_text = @raw_response.respond_to?(:content) ? @raw_response.content : @raw_response.to_s
 
@@ -25,6 +29,7 @@ module Legion
             return if result.nil? || result[:faithful]
 
             detail = result[:details] || result[:reason] || 'faithfulness check failed'
+            log.warn("[rag_guard] RAG faithfulness warning: #{detail}")
             @warnings << "RAG faithfulness warning: #{detail}"
             @timeline.record(
               category: :quality, key: 'rag:faithfulness_warning',

--- a/lib/legion/llm/pipeline/steps/rbac.rb
+++ b/lib/legion/llm/pipeline/steps/rbac.rb
@@ -13,18 +13,21 @@ module Legion
             start_time = Time.now
 
             unless defined?(::Legion::Rbac)
-              if fleet_caller?
-                msg = 'RBAC unavailable: fleet callers require RBAC enforcement (fail-closed)'
-                log.error("[llm][rbac] fleet_blocked request_id=#{@request.id} reason=rbac_unavailable")
+              if fleet_caller? || !fail_open_permitted?
+                msg = '503: RBAC unavailable — request denied ' \
+                      "(fleet=#{fleet_caller?}, fail_open=#{fail_open_permitted?})"
+                log.error("[llm][rbac] blocked request_id=#{@request.id} reason=rbac_unavailable " \
+                          "fleet=#{fleet_caller?} fail_open=#{fail_open_permitted?}")
                 record_rbac_audit(:failure, msg, start_time)
                 record_rbac_timeline("denied: #{msg}")
-                raise Legion::LLM::PipelineError.new("403 Forbidden: #{msg}", step: :rbac)
+                raise Legion::LLM::PipelineError.new(msg, step: :rbac)
               end
 
-              @warnings << 'RBAC unavailable, permitting request without enforcement'
-              log.info("[llm][rbac] unavailable request_id=#{@request.id} action=permit_without_enforcement")
-              record_rbac_audit(:success, 'permitted (rbac unavailable)', start_time)
-              record_rbac_timeline('permitted (rbac unavailable)')
+              log.warn('[llm][rbac] RBAC unavailable, permitting request (fail_open enabled) ' \
+                       "request_id=#{@request.id}")
+              @warnings << 'RBAC unavailable, permitting request (fail_open enabled)'
+              record_rbac_audit(:success, 'permitted (rbac unavailable, fail_open enabled)', start_time)
+              record_rbac_timeline('permitted (rbac unavailable, fail_open enabled)')
               return
             end
 
@@ -53,6 +56,11 @@ module Legion
           end
 
           private
+
+          def fail_open_permitted?
+            setting = Legion::Settings.dig(:rbac, :fail_open)
+            setting.nil? || setting
+          end
 
           def build_rbac_principal
             rb = @request.caller&.fetch(:requested_by, {}) || {}

--- a/lib/legion/llm/providers.rb
+++ b/lib/legion/llm/providers.rb
@@ -111,8 +111,9 @@ module Legion
 
         RubyLLM.configure do |c|
           c.anthropic_api_key = api_key
+          c.anthropic_api_base = config[:base_url] if config[:base_url]
         end
-        log.info 'Configured Anthropic provider'
+        log.info "Configured Anthropic provider#{" (#{config[:base_url]})" if config[:base_url]}"
       end
 
       def configure_openai(config)
@@ -121,8 +122,9 @@ module Legion
 
         RubyLLM.configure do |c|
           c.openai_api_key = api_key
+          c.openai_api_base = config[:base_url] if config[:base_url]
         end
-        log.info 'Configured OpenAI provider'
+        log.info "Configured OpenAI provider#{" (#{config[:base_url]})" if config[:base_url]}"
       end
 
       def configure_gemini(config)
@@ -131,8 +133,9 @@ module Legion
 
         RubyLLM.configure do |c|
           c.gemini_api_key = api_key
+          c.gemini_api_base = config[:base_url] if config[:base_url]
         end
-        log.info 'Configured Gemini provider'
+        log.info "Configured Gemini provider#{" (#{config[:base_url]})" if config[:base_url]}"
       end
 
       def configure_azure(config)

--- a/lib/legion/llm/routes.rb
+++ b/lib/legion/llm/routes.rb
@@ -46,7 +46,7 @@ module Legion
           end
         end
 
-        def dispatch_client_tool(ref, **kwargs)
+        def dispatch_client_tool(ref, **kwargs) # rubocop:disable Metrics/AbcSize
           case ref
           when 'sh'
             cmd = kwargs[:command] || kwargs[:cmd] || kwargs.values.first.to_s
@@ -81,9 +81,16 @@ module Legion
             Dir.glob(pattern).first(100).join("\n")
           when 'web_fetch'
             url = kwargs[:url] || kwargs.values.first.to_s
-            require 'net/http'
-            uri = URI(url)
-            Net::HTTP.get(uri)
+            max_length = (kwargs[:maxLength] || kwargs[:max_length])&.to_i
+            require 'legion/cli/chat/web_fetch'
+            content = Legion::CLI::Chat::WebFetch.fetch(url)
+            max_length ? content[0, max_length] : content
+          when 'web_search'
+            query = kwargs[:query] || kwargs.values.first.to_s
+            max_results = (kwargs[:max_results] || kwargs[:maxResults] || 5).to_i
+            require 'legion/cli/chat/web_search'
+            results = Legion::CLI::Chat::WebSearch.search(query, max_results: max_results, auto_fetch: false)
+            results[:results].map { |r| "### #{r[:title]}\n#{r[:url]}\n#{r[:snippet]}" }.join("\n\n")
           else
             "Tool #{ref} is not executable server-side. Use a legion_ prefixed tool instead."
           end

--- a/lib/legion/llm/routes.rb
+++ b/lib/legion/llm/routes.rb
@@ -46,7 +46,7 @@ module Legion
           end
         end
 
-        def dispatch_client_tool(ref, **kwargs) # rubocop:disable Metrics/AbcSize
+        def dispatch_client_tool(ref, **kwargs) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
           case ref
           when 'sh'
             cmd = kwargs[:command] || kwargs[:cmd] || kwargs.values.first.to_s
@@ -81,16 +81,27 @@ module Legion
             Dir.glob(pattern).first(100).join("\n")
           when 'web_fetch'
             url = kwargs[:url] || kwargs.values.first.to_s
-            max_length = (kwargs[:maxLength] || kwargs[:max_length])&.to_i
-            require 'legion/cli/chat/web_fetch'
-            content = Legion::CLI::Chat::WebFetch.fetch(url)
-            max_length ? content[0, max_length] : content
+            raw_max_length = kwargs[:maxLength] || kwargs[:max_length]
+            max_length = raw_max_length.nil? ? nil : [raw_max_length.to_i, 0].max
+            begin
+              require 'legion/cli/chat/web_fetch'
+              content = Legion::CLI::Chat::WebFetch.fetch(url)
+              max_length ? content[0, max_length] : content
+            rescue LoadError => e
+              missing = e.respond_to?(:path) && e.path ? e.path : 'legion/cli/chat/web_fetch'
+              "web_fetch is unavailable: missing optional dependency #{missing}"
+            end
           when 'web_search'
             query = kwargs[:query] || kwargs.values.first.to_s
             max_results = (kwargs[:max_results] || kwargs[:maxResults] || 5).to_i
-            require 'legion/cli/chat/web_search'
-            results = Legion::CLI::Chat::WebSearch.search(query, max_results: max_results, auto_fetch: false)
-            results[:results].map { |r| "### #{r[:title]}\n#{r[:url]}\n#{r[:snippet]}" }.join("\n\n")
+            begin
+              require 'legion/cli/chat/web_search'
+              results = Legion::CLI::Chat::WebSearch.search(query, max_results: max_results, auto_fetch: false)
+              results[:results].map { |r| "### #{r[:title]}\n#{r[:url]}\n#{r[:snippet]}" }.join("\n\n")
+            rescue LoadError => e
+              missing = e.respond_to?(:path) && e.path ? e.path : 'legion/cli/chat/web_search'
+              "web_search is unavailable: missing optional dependency #{missing}"
+            end
           else
             "Tool #{ref} is not executable server-side. Use a legion_ prefixed tool instead."
           end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.10'
+    VERSION = '0.7.11'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.12'
+    VERSION = '0.7.13'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.8'
+    VERSION = '0.7.9'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.14'
+    VERSION = '0.7.15'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.9'
+    VERSION = '0.7.10'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.13'
+    VERSION = '0.7.14'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.11'
+    VERSION = '0.7.12'
   end
 end

--- a/spec/legion/llm/pipeline/pre_rollout_integration_spec.rb
+++ b/spec/legion/llm/pipeline/pre_rollout_integration_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Pipeline pre-rollout integration' do
     it 'permits request when Legion::Rbac is not loaded' do
       result = Legion::LLM.chat(message: 'hello', caller: { source: 'test' })
 
-      expect(result.warnings).to include('RBAC unavailable, permitting request without enforcement')
+      expect(result.warnings).to include('RBAC unavailable, permitting request (fail_open enabled)')
       expect(result.audit).to have_key(:'rbac:permission_check')
       expect(result.audit[:'rbac:permission_check'][:outcome]).to eq(:success)
     end

--- a/spec/legion/llm/pipeline/steps/classification_spec.rb
+++ b/spec/legion/llm/pipeline/steps/classification_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
       end
     end
 
-    context 'PII detection' do
+    context 'PII detection (core patterns, strict_hipaa=false)' do
       it 'detects SSN pattern' do
         step = build_step(
           classification: { level: :internal },
@@ -138,6 +138,31 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
         step.step_classification
         expect(step.enrichments['classification:scan'][:contains_pii]).to be true
         expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:phone)
+      end
+
+      it 'does not detect extended patterns when strict_hipaa is off' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'server at 192.168.1.100 is down' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be false
+        expect(step.enrichments['classification:scan'][:detected_patterns]).not_to include(:ip_address)
+      end
+
+      it 'sets contains_pii false when no PII found' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'what is 2 + 2?' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be false
+      end
+    end
+
+    context 'PII detection (extended patterns, strict_hipaa=true)' do
+      before do
+        Legion::Settings[:compliance] = { strict_hipaa: true }
       end
 
       it 'detects IP address pattern' do
@@ -190,13 +215,14 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
         expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:vin)
       end
 
-      it 'sets contains_pii false when no PII found' do
+      it 'also detects core patterns when strict_hipaa is on' do
         step = build_step(
           classification: { level: :internal },
-          messages:       [{ role: :user, content: 'what is 2 + 2?' }]
+          messages:       [{ role: :user, content: 'my SSN is 123-45-6789' }]
         )
         step.step_classification
-        expect(step.enrichments['classification:scan'][:contains_pii]).to be false
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be true
+        expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:ssn)
       end
     end
 
@@ -268,6 +294,124 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
         )
         step.step_classification
         expect(step.warnings).to be_empty
+      end
+    end
+
+    context 'redaction (redact_pii=false by default)' do
+      it 'does not modify message content when redaction is disabled' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'my SSN is 123-45-6789' }]
+        )
+        step.step_classification
+        expect(step.request.messages.first[:content]).to eq('my SSN is 123-45-6789')
+        expect(step.enrichments).not_to have_key('classification:redaction')
+      end
+    end
+
+    context 'redaction (redact_pii=true)' do
+      before do
+        Legion::Settings[:compliance] = { redact_pii: true }
+      end
+
+      it 'replaces detected PII with [REDACTED] in message content' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'my SSN is 123-45-6789' }]
+        )
+        step.step_classification
+        expect(step.request.messages.first[:content]).to eq('my SSN is [REDACTED]')
+      end
+
+      it 'replaces multiple PII patterns' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'SSN 123-45-6789 email john@test.com call 612-555-1234' }]
+        )
+        step.step_classification
+        content = step.request.messages.first[:content]
+        expect(content).not_to include('123-45-6789')
+        expect(content).not_to include('john@test.com')
+        expect(content).not_to include('612-555-1234')
+      end
+
+      it 'replaces PHI keywords when PHI is detected' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'patient diagnosis is hypertension' }]
+        )
+        step.step_classification
+        content = step.request.messages.first[:content]
+        expect(content).not_to match(/\bpatient\b/i)
+        expect(content).not_to match(/\bdiagnosis\b/i)
+      end
+
+      it 'records redaction enrichment' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'my SSN is 123-45-6789' }]
+        )
+        step.step_classification
+        expect(step.enrichments).to have_key('classification:redaction')
+        redaction = step.enrichments['classification:redaction']
+        expect(redaction[:redacted]).to be true
+        expect(redaction[:placeholder]).to eq('[REDACTED]')
+        expect(redaction[:patterns_redacted]).to include(:ssn)
+        expect(redaction[:timestamp]).to be_a(Time)
+      end
+
+      it 'does not redact when no PII or PHI is found' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'what is 2 + 2?' }]
+        )
+        step.step_classification
+        expect(step.request.messages.first[:content]).to eq('what is 2 + 2?')
+        expect(step.enrichments).not_to have_key('classification:redaction')
+      end
+
+      it 'skips non-string content in messages' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [
+            { role: :user, content: 'my SSN is 123-45-6789' },
+            { role: :user, content: nil }
+          ]
+        )
+        step.step_classification
+        expect(step.request.messages.first[:content]).to eq('my SSN is [REDACTED]')
+        expect(step.request.messages.last[:content]).to be_nil
+      end
+    end
+
+    context 'redaction with custom placeholder' do
+      before do
+        Legion::Settings[:compliance] = { redact_pii: true, redaction_placeholder: '***' }
+      end
+
+      it 'uses the custom placeholder' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'my SSN is 123-45-6789' }]
+        )
+        step.step_classification
+        expect(step.request.messages.first[:content]).to eq('my SSN is ***')
+        expect(step.enrichments['classification:redaction'][:placeholder]).to eq('***')
+      end
+    end
+
+    context 'redaction with strict_hipaa=true' do
+      before do
+        Legion::Settings[:compliance] = { redact_pii: true, strict_hipaa: true }
+      end
+
+      it 'redacts extended patterns when strict_hipaa is on' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'server at 192.168.1.100 is down' }]
+        )
+        step.step_classification
+        expect(step.request.messages.first[:content]).to eq('server at [REDACTED] is down')
       end
     end
   end

--- a/spec/legion/llm/pipeline/steps/classification_spec.rb
+++ b/spec/legion/llm/pipeline/steps/classification_spec.rb
@@ -414,5 +414,122 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
         expect(step.request.messages.first[:content]).to eq('server at [REDACTED] is down')
       end
     end
+
+    context 'PHI cloud provider gate' do
+      def build_gate_step(provider: nil, messages: nil)
+        msgs = messages || [{ role: :user, content: 'patient medication list: lisinopril' }]
+        routing = { provider: provider, model: nil }
+        request = Legion::LLM::Pipeline::Request.build(
+          messages: msgs,
+          routing:  routing
+        )
+        klass.new(request)
+      end
+
+      context 'when phi_block_cloud=false (default) with restricted + cloud provider' do
+        before do
+          Legion::Settings[:llm] = { default_provider: :anthropic }
+        end
+
+        it 'permits with a warning' do
+          step = build_gate_step(provider: :anthropic)
+          step.step_classification
+          expect(step.enrichments['classification:scan'][:effective_level]).to eq(:restricted)
+          expect(step.warnings).to include(
+            a_string_matching(/PHI content routing to cloud provider anthropic/)
+          )
+        end
+      end
+
+      context 'when phi_block_cloud=true with restricted + cloud provider' do
+        before do
+          Legion::Settings[:compliance] = { phi_block_cloud: true }
+          Legion::Settings[:llm] = { default_provider: :anthropic }
+        end
+
+        it 'raises PipelineError' do
+          step = build_gate_step(provider: :anthropic)
+          expect { step.step_classification }.to raise_error(
+            Legion::LLM::PipelineError,
+            /PHI content.*cannot be sent to cloud provider anthropic/
+          )
+        end
+      end
+
+      context 'when phi_block_cloud=true with restricted + local provider (ollama)' do
+        before do
+          Legion::Settings[:compliance] = { phi_block_cloud: true }
+          Legion::Settings[:llm] = { default_provider: :ollama }
+        end
+
+        it 'permits without warning' do
+          step = build_gate_step(provider: :ollama)
+          step.step_classification
+          expect(step.enrichments['classification:scan'][:effective_level]).to eq(:restricted)
+          expect(step.warnings).not_to include(
+            a_string_matching(/PHI content routing to cloud provider/)
+          )
+        end
+      end
+
+      context 'when phi_block_cloud=true with non-restricted level + cloud provider' do
+        before do
+          Legion::Settings[:compliance] = { phi_block_cloud: true }
+          Legion::Settings[:llm] = { default_provider: :anthropic }
+        end
+
+        it 'permits because gate only fires on restricted' do
+          step = build_gate_step(
+            provider: :anthropic,
+            messages: [{ role: :user, content: 'what is 2 + 2?' }]
+          )
+          step.step_classification
+          expect(step.enrichments['classification:scan'][:effective_level]).to eq(:public)
+          expect(step.warnings).to be_empty
+        end
+      end
+
+      context 'with custom cloud_providers list' do
+        before do
+          Legion::Settings[:compliance] = {
+            phi_block_cloud: true,
+            cloud_providers: %i[anthropic openai]
+          }
+          Legion::Settings[:llm] = { default_provider: :bedrock }
+        end
+
+        it 'permits bedrock when it is not in the custom cloud list' do
+          step = build_gate_step(provider: :bedrock)
+          step.step_classification
+          expect(step.enrichments['classification:scan'][:effective_level]).to eq(:restricted)
+          expect(step.warnings).not_to include(
+            a_string_matching(/PHI content routing to cloud provider/)
+          )
+        end
+
+        it 'blocks anthropic when it is in the custom cloud list' do
+          step = build_gate_step(provider: :anthropic)
+          expect { step.step_classification }.to raise_error(
+            Legion::LLM::PipelineError,
+            /cannot be sent to cloud provider anthropic/
+          )
+        end
+      end
+
+      context 'when provider comes from default_provider setting (no explicit routing)' do
+        before do
+          Legion::Settings[:compliance] = { phi_block_cloud: true }
+          Legion::Settings[:llm] = { default_provider: :openai }
+        end
+
+        it 'blocks based on default provider when no explicit provider in routing' do
+          step = build_gate_step(provider: nil)
+          expect { step.step_classification }.to raise_error(
+            Legion::LLM::PipelineError,
+            /cannot be sent to cloud provider openai/
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/legion/llm/pipeline/steps/classification_spec.rb
+++ b/spec/legion/llm/pipeline/steps/classification_spec.rb
@@ -29,16 +29,60 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
 
   describe '#step_classification' do
     context 'when classification is nil' do
-      it 'skips without writing to audit' do
+      it 'runs scan with :public baseline and writes audit entry' do
+        step = build_step(classification: nil)
+        step.step_classification
+        expect(step.audit).to have_key(:'classification:scan')
+        expect(step.audit[:'classification:scan'][:outcome]).to eq(:success)
+      end
+
+      it 'runs scan with :public baseline and writes enrichments' do
+        step = build_step(classification: nil)
+        step.step_classification
+        expect(step.enrichments).to have_key('classification:scan')
+        expect(step.enrichments['classification:scan'][:declared_level]).to eq(:public)
+      end
+    end
+
+    context 'when compliance.default_level is configured' do
+      before do
+        allow(Legion::Settings).to receive(:dig).and_call_original
+        allow(Legion::Settings).to receive(:dig).with(:compliance, :default_level).and_return('internal')
+        allow(Legion::Settings).to receive(:dig).with(:compliance, :classification_level).and_return(nil)
+        allow(Legion::Settings).to receive(:dig).with(:compliance, :classification_scan).and_return(nil)
+      end
+
+      it 'uses configured default level as baseline' do
+        step = build_step(classification: nil)
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:declared_level]).to eq(:internal)
+      end
+    end
+
+    context 'when compliance.classification_scan is false' do
+      before do
+        allow(Legion::Settings).to receive(:dig).and_call_original
+        allow(Legion::Settings).to receive(:dig).with(:compliance, :classification_scan).and_return(false)
+      end
+
+      it 'skips the step entirely' do
         step = build_step(classification: nil)
         step.step_classification
         expect(step.audit).not_to have_key(:'classification:scan')
-      end
-
-      it 'skips without writing to enrichments' do
-        step = build_step(classification: nil)
-        step.step_classification
         expect(step.enrichments).not_to have_key('classification:scan')
+      end
+    end
+
+    context 'when PHI is detected in an unclassified request' do
+      it 'upgrades from :public baseline to :restricted' do
+        step = build_step(
+          classification: nil,
+          messages:       [{ role: :user, content: 'patient medication list: lisinopril' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:declared_level]).to eq(:public)
+        expect(step.enrichments['classification:scan'][:effective_level]).to eq(:restricted)
+        expect(step.enrichments['classification:scan'][:upgraded]).to be true
       end
     end
 

--- a/spec/legion/llm/pipeline/steps/classification_spec.rb
+++ b/spec/legion/llm/pipeline/steps/classification_spec.rb
@@ -96,6 +96,56 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
         expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:phone)
       end
 
+      it 'detects IP address pattern' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'server at 192.168.1.100 is down' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be true
+        expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:ip_address)
+      end
+
+      it 'detects date of birth pattern' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'DOB: 01/15/1985' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be true
+        expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:date_of_birth)
+      end
+
+      it 'detects URL pattern' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'visit https://patient-portal.example.com/records' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be true
+        expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:url)
+      end
+
+      it 'detects MRN with number pattern' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'MRN: 12345678' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be true
+        expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:mrn)
+      end
+
+      it 'detects VIN pattern' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'vehicle 1HGBH41JXMN109186 was involved' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_pii]).to be true
+        expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:vin)
+      end
+
       it 'sets contains_pii false when no PII found' do
         step = build_step(
           classification: { level: :internal },
@@ -115,6 +165,15 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
         step.step_classification
         expect(step.enrichments['classification:scan'][:contains_phi]).to be true
         expect(step.enrichments['classification:scan'][:detected_patterns]).to include(:phi_keyword)
+      end
+
+      it 'detects expanded PHI keywords' do
+        step = build_step(
+          classification: { level: :internal },
+          messages:       [{ role: :user, content: 'health-plan beneficiary admission records' }]
+        )
+        step.step_classification
+        expect(step.enrichments['classification:scan'][:contains_phi]).to be true
       end
 
       it 'sets contains_phi false when no PHI found' do

--- a/spec/legion/llm/pipeline/steps/classification_spec.rb
+++ b/spec/legion/llm/pipeline/steps/classification_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
           step.step_classification
           expect(step.enrichments['classification:scan'][:effective_level]).to eq(:restricted)
           expect(step.warnings).to include(
-            a_string_matching(/PHI content routing to cloud provider anthropic/)
+            a_string_matching(%r{Restricted/sensitive content routing to cloud provider anthropic})
           )
         end
       end
@@ -451,7 +451,7 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
           step = build_gate_step(provider: :anthropic)
           expect { step.step_classification }.to raise_error(
             Legion::LLM::PipelineError,
-            /PHI content.*cannot be sent to cloud provider anthropic/
+            %r{Restricted/sensitive content.*cannot be sent to cloud provider anthropic}
           )
         end
       end
@@ -467,7 +467,7 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
           step.step_classification
           expect(step.enrichments['classification:scan'][:effective_level]).to eq(:restricted)
           expect(step.warnings).not_to include(
-            a_string_matching(/PHI content routing to cloud provider/)
+            a_string_matching(%r{Restricted/sensitive content routing to cloud provider})
           )
         end
       end
@@ -503,7 +503,7 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Classification do
           step.step_classification
           expect(step.enrichments['classification:scan'][:effective_level]).to eq(:restricted)
           expect(step.warnings).not_to include(
-            a_string_matching(/PHI content routing to cloud provider/)
+            a_string_matching(%r{Restricted/sensitive content routing to cloud provider})
           )
         end
 

--- a/spec/legion/llm/pipeline/steps/rag_guard_spec.rb
+++ b/spec/legion/llm/pipeline/steps/rag_guard_spec.rb
@@ -51,5 +51,19 @@ RSpec.describe Legion::LLM::Pipeline::Steps::RagGuard do
       step.check_rag_faithfulness
       expect(step.warnings).to be_empty
     end
+
+    it 'logs a warning when RAG context is present but Hooks::RagGuard is not defined' do
+      hide_const('Legion::LLM::Hooks::RagGuard') if defined?(Legion::LLM::Hooks::RagGuard)
+      step = klass.new
+      logger = instance_double(Legion::Logging::Logger, warn: nil, debug: nil, info: nil)
+      allow(step).to receive(:log).and_return(logger)
+
+      step.check_rag_faithfulness
+
+      expect(logger).to have_received(:warn).with(
+        a_string_matching(/RAG context present but no Hooks::RagGuard registered/)
+      )
+      expect(step.warnings).to be_empty
+    end
   end
 end

--- a/spec/legion/llm/pipeline/steps/rbac_spec.rb
+++ b/spec/legion/llm/pipeline/steps/rbac_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Rbac do
         expect { step.step_rbac }.not_to raise_error
       end
 
-      it 'adds a warning about rbac being unavailable' do
+      it 'adds a warning about rbac being unavailable with fail_open' do
         step = klass.new(request)
         step.step_rbac
-        expect(step.warnings).to include(match(/rbac unavailable/i))
+        expect(step.warnings).to include(match(/rbac unavailable.*fail_open/i))
       end
 
       it 'records success outcome in audit' do
@@ -63,6 +63,73 @@ RSpec.describe Legion::LLM::Pipeline::Steps::Rbac do
         step.step_rbac
         keys = step.timeline.events.map { |e| e[:key] }
         expect(keys).to include('rbac:permission_check')
+      end
+    end
+
+    context 'when legion-rbac is not available and fail_open=true (explicit)' do
+      before do
+        hide_const('Legion::Rbac') if defined?(Legion::Rbac)
+        Legion::Settings[:rbac] = { fail_open: true }
+      end
+
+      it 'permits non-fleet callers with warning' do
+        step = klass.new(request)
+        expect { step.step_rbac }.not_to raise_error
+        expect(step.warnings).to include(match(/fail_open/i))
+      end
+    end
+
+    context 'when legion-rbac is not available and fail_open=false' do
+      before do
+        hide_const('Legion::Rbac') if defined?(Legion::Rbac)
+        Legion::Settings[:rbac] = { fail_open: false }
+      end
+
+      it 'raises PipelineError for non-fleet callers' do
+        step = klass.new(request)
+        expect { step.step_rbac }.to raise_error(Legion::LLM::PipelineError, /503/)
+      end
+
+      it 'includes fail_open=false in error message' do
+        step = klass.new(request)
+        expect { step.step_rbac }.to raise_error(Legion::LLM::PipelineError, /fail_open=false/)
+      end
+
+      it 'records failure in audit' do
+        step = klass.new(request)
+        step.step_rbac rescue Legion::LLM::PipelineError # rubocop:disable Style/RescueModifier
+        expect(step.audit[:'rbac:permission_check'][:outcome]).to eq(:failure)
+      end
+    end
+
+    context 'when legion-rbac is not available and caller is fleet (regardless of fail_open)' do
+      let(:fleet_request) do
+        Legion::LLM::Pipeline::Request.build(
+          messages: [{ role: :user, content: 'hello' }],
+          caller:   {
+            requested_by: { id: 'system', type: :system },
+            agent:        { id: 'fleet:worker-1' }
+          }
+        )
+      end
+
+      before { hide_const('Legion::Rbac') if defined?(Legion::Rbac) }
+
+      it 'raises PipelineError even when fail_open=true' do
+        Legion::Settings[:rbac] = { fail_open: true }
+        step = klass.new(fleet_request)
+        expect { step.step_rbac }.to raise_error(Legion::LLM::PipelineError, /503/)
+      end
+
+      it 'raises PipelineError when fail_open=false' do
+        Legion::Settings[:rbac] = { fail_open: false }
+        step = klass.new(fleet_request)
+        expect { step.step_rbac }.to raise_error(Legion::LLM::PipelineError, /503/)
+      end
+
+      it 'raises PipelineError when fail_open setting is not present' do
+        step = klass.new(fleet_request)
+        expect { step.step_rbac }.to raise_error(Legion::LLM::PipelineError, /503/)
       end
     end
 

--- a/spec/legion/llm/providers_base_url_spec.rb
+++ b/spec/legion/llm/providers_base_url_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Legion::LLM::Providers, 'base_url forwarding' do
+  let(:host) do
+    Class.new do
+      include Legion::LLM::Providers
+      include Legion::Logging::Helper
+
+      def settings
+        Legion::LLM.settings
+      end
+    end.new
+  end
+
+  let(:ruby_llm_config) { double('config') }
+
+  before do
+    allow(RubyLLM).to receive(:configure).and_yield(ruby_llm_config)
+    hide_const('Legion::Identity::Broker')
+  end
+
+  describe '#configure_anthropic' do
+    before do
+      allow(ruby_llm_config).to receive(:anthropic_api_key=)
+      allow(ruby_llm_config).to receive(:anthropic_api_base=)
+    end
+
+    it 'sets anthropic_api_base when base_url is present' do
+      host.send(:configure_anthropic, { api_key: 'sk-ant', base_url: 'https://gateway.example.com' })
+      expect(ruby_llm_config).to have_received(:anthropic_api_base=).with('https://gateway.example.com')
+    end
+
+    it 'does not set anthropic_api_base when base_url is absent' do
+      host.send(:configure_anthropic, { api_key: 'sk-ant' })
+      expect(ruby_llm_config).not_to have_received(:anthropic_api_base=)
+    end
+  end
+
+  describe '#configure_openai' do
+    before do
+      allow(ruby_llm_config).to receive(:openai_api_key=)
+      allow(ruby_llm_config).to receive(:openai_api_base=)
+    end
+
+    it 'sets openai_api_base when base_url is present' do
+      host.send(:configure_openai, { api_key: 'sk-oai', base_url: 'https://gateway.example.com' })
+      expect(ruby_llm_config).to have_received(:openai_api_base=).with('https://gateway.example.com')
+    end
+
+    it 'does not set openai_api_base when base_url is absent' do
+      host.send(:configure_openai, { api_key: 'sk-oai' })
+      expect(ruby_llm_config).not_to have_received(:openai_api_base=)
+    end
+  end
+
+  describe '#configure_gemini' do
+    before do
+      allow(ruby_llm_config).to receive(:gemini_api_key=)
+      allow(ruby_llm_config).to receive(:gemini_api_base=)
+    end
+
+    it 'sets gemini_api_base when base_url is present' do
+      host.send(:configure_gemini, { api_key: 'gem-key', base_url: 'https://gateway.example.com' })
+      expect(ruby_llm_config).to have_received(:gemini_api_base=).with('https://gateway.example.com')
+    end
+
+    it 'does not set gemini_api_base when base_url is absent' do
+      host.send(:configure_gemini, { api_key: 'gem-key' })
+      expect(ruby_llm_config).not_to have_received(:gemini_api_base=)
+    end
+  end
+end

--- a/spec/legion/llm/providers_base_url_spec.rb
+++ b/spec/legion/llm/providers_base_url_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 RSpec.describe Legion::LLM::Providers, 'base_url forwarding' do
   let(:host) do
     Class.new do


### PR DESCRIPTION
## Summary

- **web_fetch** client tool in `lib/legion/llm/routes.rb` now delegates to `Legion::CLI::Chat::WebFetch.fetch` instead of bare `Net::HTTP.get(uri)` — gains SSL support, redirect following, HTML-to-markdown conversion, and `maxLength` truncation.
- **web_search** client tool dispatch added via `Legion::CLI::Chat::WebSearch.search` — previously fell through to generic "not executable server-side" error.
- **PII/PHI classification** expanded from 3 to 12 HIPAA Safe Harbor identifier patterns (added IP address, date of birth, zip code, MRN, account number, license number, URL, VIN, NPI) and from 11 to 20 PHI keywords (added health-plan, beneficiary, insurance-id, group-number, lab-result, radiology, pathology, admission, discharge, procedure).
- **PII/PHI redaction mode**: `compliance.redact_pii` (default: `false`) replaces detected PII/PHI patterns with a configurable placeholder token (`compliance.redaction_placeholder`, default: `[REDACTED]`) in message content before the pipeline continues.
- **Strict HIPAA mode**: `compliance.strict_hipaa` (default: `false`) toggles between scanning only the core 3 patterns (SSN, email, phone) and the full 12 HIPAA patterns. Deployments that do not need HIPAA-grade detection get a lighter scan by default.
- **Classification always-scan fix**: classification step now always runs the PII/PHI scan even on unclassified requests, defaulting to `:public` baseline. Previously, unclassified requests bypassed the privacy gate entirely. Configurable via `compliance.default_level` (default: `:public`) and `compliance.classification_scan` (default: `true`).
- **PHI cloud provider gate**: `compliance.phi_block_cloud` (default: `false`) blocks restricted-classified requests from cloud providers when enabled. When disabled (default, fail-open), permits the request with a warning. Cloud provider list configurable via `compliance.cloud_providers` (default: `[:anthropic, :openai, :gemini, :bedrock, :azure]`). Works regardless of whether routing is enabled.
- **Provider base_url forwarding**: `configure_anthropic`, `configure_openai`, and `configure_gemini` now pass `base_url` through to RubyLLM when present, enabling custom API gateways and proxies.
- **RAG faithfulness guard**: `Pipeline::Steps::RagGuard` now logs a `warn` when RAG context is present but no `Hooks::RagGuard` is registered, instead of silently returning. Also logs at warn level when faithfulness check fails.
- **RBAC fail_open config**: `Pipeline::Steps::Rbac` now respects `rbac.fail_open` setting (default: `true`) when `Legion::Rbac` is unavailable. Fleet callers are always blocked regardless of setting. Non-fleet callers are permitted with a warning when `fail_open` is true, or blocked with 503 when false.
- Version bumped to 0.7.15.

Fixes LegionIO/LegionIO#153
Fixes LegionIO/LegionIO#154
Closes #73
Fixes #68
Fixes #70
Fixes #71
Fixes #69
Fixes #72

## Test plan

- [ ] Verify `web_fetch` tool returns markdown-converted content for HTTPS URLs
- [ ] Verify `web_fetch` respects `maxLength` truncation
- [ ] Verify `web_search` tool returns formatted search results
- [ ] Verify new PII patterns detect IP address, date of birth, URL, MRN, and VIN (with `strict_hipaa=true`)
- [ ] Verify expanded PHI keywords detect health-plan, beneficiary, admission
- [ ] Verify unclassified requests still get PII/PHI scan with `:public` baseline
- [ ] Verify `compliance.default_level` setting overrides the `:public` default
- [ ] Verify `compliance.classification_scan: false` disables the scan entirely
- [ ] Verify PHI in unclassified requests upgrades to `:restricted`
- [ ] Verify `strict_hipaa=false` (default) scans only core 3 patterns (SSN, email, phone)
- [ ] Verify `strict_hipaa=true` scans all 12 HIPAA patterns
- [ ] Verify `redact_pii=false` (default) leaves message content unchanged
- [ ] Verify `redact_pii=true` replaces detected PII with `[REDACTED]` in message content
- [ ] Verify `redact_pii=true` with custom placeholder uses the custom string
- [ ] Verify redaction enrichment is recorded when redaction occurs
- [ ] Verify `phi_block_cloud=false` (default) permits restricted+cloud with warning
- [ ] Verify `phi_block_cloud=true` blocks restricted+cloud with PipelineError
- [ ] Verify `phi_block_cloud=true` permits restricted+local (ollama) without warning
- [ ] Verify `phi_block_cloud=true` permits non-restricted+cloud (gate only fires on restricted)
- [ ] Verify custom `compliance.cloud_providers` list is respected
- [ ] Verify gate uses `default_provider` when no explicit provider in routing
- [ ] Verify `base_url` is forwarded to RubyLLM for Anthropic, OpenAI, and Gemini providers
- [ ] Verify providers without `base_url` set do not call `*_api_base=`
- [ ] Verify RAG guard logs warning when `Hooks::RagGuard` is not defined but RAG context is present
- [ ] Verify RAG faithfulness failure logs at warn level
- [ ] Verify RBAC step permits non-fleet callers with warning when `rbac.fail_open` is true (default)
- [ ] Verify RBAC step blocks non-fleet callers with 503 when `rbac.fail_open` is false
- [ ] Verify RBAC step always blocks fleet callers regardless of `fail_open` setting
- [ ] Confirm existing rspec suite passes (1941 examples, 1 pre-existing unrelated failure in KnowledgeCapture async test)
- [ ] Confirm rubocop passes on modified files