### PR TITLE
fix: daemon client settings fallback for standalone/CLI contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.7.7] - 2026-04-21
+
+### Fixed
+- DaemonClient settings fallback for standalone/CLI contexts — `resolve_llm_settings` now gracefully falls back to `Legion::Settings[:llm]` when `Legion::LLM.settings` is unavailable, preventing failures in CLI usage
+
 ## [0.7.6] - 2026-04-14
 
 ### Added

--- a/lib/legion/llm/daemon_client.rb
+++ b/lib/legion/llm/daemon_client.rb
@@ -189,13 +189,9 @@ module Legion
       # Legion::Settings[:llm] (loaded by CLI ensure_settings before
       # daemon_client is required standalone).
       def resolve_llm_settings
-        if defined?(Legion::LLM) && Legion::LLM.respond_to?(:settings)
-          return Legion::LLM.settings
-        end
+        return Legion::LLM.settings if defined?(Legion::LLM) && Legion::LLM.respond_to?(:settings)
 
-        if defined?(Legion::Settings) && Legion::Settings.respond_to?(:[])
-          return Legion::Settings[:llm]
-        end
+        return Legion::Settings[:llm] if defined?(Legion::Settings) && Legion::Settings.respond_to?(:[])
 
         nil
       end

--- a/lib/legion/llm/daemon_client.rb
+++ b/lib/legion/llm/daemon_client.rb
@@ -171,9 +171,7 @@ module Legion
       # ── private helpers ────────────────────────────────────────────────
 
       def fetch_daemon_url
-        return nil unless defined?(Legion::LLM) && Legion::LLM.respond_to?(:settings)
-
-        settings = Legion::LLM.settings
+        settings = resolve_llm_settings
         return nil unless settings.is_a?(Hash)
 
         daemon = settings[:daemon] || settings['daemon']
@@ -183,6 +181,22 @@ module Legion
         daemon[:url] || daemon['url']
       rescue StandardError => e
         handle_exception(e, level: :warn)
+        nil
+      end
+
+      # Resolves LLM settings from whichever source is available.
+      # Prefers Legion::LLM.settings (fully started), falls back to
+      # Legion::Settings[:llm] (loaded by CLI ensure_settings before
+      # daemon_client is required standalone).
+      def resolve_llm_settings
+        if defined?(Legion::LLM) && Legion::LLM.respond_to?(:settings)
+          return Legion::LLM.settings
+        end
+
+        if defined?(Legion::Settings) && Legion::Settings.respond_to?(:[])
+          return Legion::Settings[:llm]
+        end
+
         nil
       end
 
@@ -243,7 +257,8 @@ module Legion
         end
       end
 
-      private_class_method :fetch_daemon_url, :safe_parse, :extract_retry_after, :interpret_inference_response
+      private_class_method :fetch_daemon_url, :resolve_llm_settings, :safe_parse, :extract_retry_after,
+                           :interpret_inference_response
     end
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.6'
+    VERSION = '0.7.7'
   end
 end

--- a/spec/legion/llm/daemon_client_spec.rb
+++ b/spec/legion/llm/daemon_client_spec.rb
@@ -73,8 +73,26 @@ RSpec.describe Legion::LLM::DaemonClient do
         allow(Legion::LLM).to receive(:respond_to?).with(:settings).and_return(false)
       end
 
-      it 'returns nil' do
+      it 'returns nil when Legion::Settings is also unavailable' do
+        stub_const('Legion::Settings', Class.new do
+          def self.respond_to?(method, *)
+            return false if method == :[]
+
+            super
+          end
+        end)
         expect(described_class.daemon_url).to be_nil
+      end
+    end
+
+    context 'when Legion::LLM.settings is unavailable but Legion::Settings has llm config' do
+      before do
+        allow(Legion::LLM).to receive(:respond_to?).with(:settings).and_return(false)
+        allow(Legion::Settings).to receive(:[]).with(:llm).and_return({ daemon: { url: 'http://fallback:4000' } })
+      end
+
+      it 'falls back to Legion::Settings[:llm] for the daemon url' do
+        expect(described_class.daemon_url).to eq('http://fallback:4000')
       end
     end
 


### PR DESCRIPTION
## Summary

`DaemonClient.fetch_daemon_url` was too rigidly dependent on `Legion::LLM.settings`, which fails in standalone CLI contexts where the daemon client is loaded before the full LLM module starts.

New `resolve_llm_settings` method implements a fallback hierarchy:
1. `Legion::LLM.settings` (preferred — fully started state)
2. `Legion::Settings[:llm]` (available in CLI contexts before LLM start)
3. `nil` (neither available)

## Files Changed

| File | Change |
|---|---|
| `lib/legion/llm/daemon_client.rb` | New `resolve_llm_settings` with fallback chain (+23/-4) |
| `spec/legion/llm/daemon_client_spec.rb` | Tests for fallback behavior (+20/-1) |

## Test plan

- [ ] Start daemon client via `legion chat` (full boot) → verify uses `Legion::LLM.settings`
- [ ] Start daemon client standalone (CLI context) → verify falls back to `Legion::Settings[:llm]`
- [ ] Neither settings source available → verify returns `nil` gracefully
- [ ] Run specs: `bundle exec rspec spec/legion/llm/daemon_client_spec.rb`