### PR TITLE
refactor(llm): let provider_supports_embeddings? probe Bedrock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [0.7.16] - 2026-04-22
 
-### Changed
+### Internal
 - `Legion::LLM.provider_supports_embeddings?` no longer hardcodes `:bedrock` as unsupported. Bedrock does expose embedding models (`PROVIDER_EMBEDDING_MODELS` already ships `bedrock: amazon.titan-embed-text-v2:0`); the hardcoded exclusion masked the real gap — the `Bedrock` provider class does not yet implement `render_embedding_payload`. Behavior is byte-identical today (the `instance_method` probe still falls through to `rescue NameError` → `false`), but once a sibling contribution adds `render_embedding_payload` to the Bedrock provider, Bedrock will be detected as embedding-capable with no further change required here. `:anthropic` stays hardcoded-false because its native API has no embedding endpoint. Adds `spec/legion/llm/provider_supports_embeddings_spec.rb` covering each provider class.
 
 ## [0.7.15] - 2026-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- `Legion::LLM.provider_supports_embeddings?` no longer hardcodes `:bedrock` as unsupported. Bedrock does expose embedding models (`PROVIDER_EMBEDDING_MODELS` already ships `bedrock: amazon.titan-embed-text-v2:0`); the hardcoded exclusion masked the real gap — the `Bedrock` provider class does not yet implement `render_embedding_payload`. Behavior is byte-identical today (the `instance_method` probe still falls through to `rescue NameError` → `false`), but once a sibling contribution adds `render_embedding_payload` to the Bedrock provider, Bedrock will be detected as embedding-capable with no further change required here. `:anthropic` stays hardcoded-false because its native API has no embedding endpoint. Adds `spec/legion/llm/provider_supports_embeddings_spec.rb` covering each provider class.
+
 ## [0.7.15] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.16] - 2026-04-22
+
 ### Changed
 - `Legion::LLM.provider_supports_embeddings?` no longer hardcodes `:bedrock` as unsupported. Bedrock does expose embedding models (`PROVIDER_EMBEDDING_MODELS` already ships `bedrock: amazon.titan-embed-text-v2:0`); the hardcoded exclusion masked the real gap — the `Bedrock` provider class does not yet implement `render_embedding_payload`. Behavior is byte-identical today (the `instance_method` probe still falls through to `rescue NameError` → `false`), but once a sibling contribution adds `render_embedding_payload` to the Bedrock provider, Bedrock will be detected as embedding-capable with no further change required here. `:anthropic` stays hardcoded-false because its native API has no embedding endpoint. Adds `spec/legion/llm/provider_supports_embeddings_spec.rb` covering each provider class.
 

--- a/lib/legion/llm.rb
+++ b/lib/legion/llm.rb
@@ -1072,7 +1072,10 @@ module Legion
         provider = provider&.to_sym
         return false unless provider
         return true if %i[ollama azure].include?(provider)
-        return false if %i[anthropic bedrock].include?(provider)
+        # Anthropic's native API has no embedding endpoint. Bedrock does (via Titan),
+        # so let the instance_method probe below decide — the exclusion was masking
+        # a missing render_embedding_payload implementation, not an API limitation.
+        return false if %i[anthropic].include?(provider)
 
         klass = RubyLLM::Provider.resolve(provider)
         return false unless klass

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.7.15'
+    VERSION = '0.7.16'
   end
 end

--- a/spec/legion/llm/provider_supports_embeddings_spec.rb
+++ b/spec/legion/llm/provider_supports_embeddings_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Legion::LLM.provider_supports_embeddings?' do
+  subject(:supports?) { Legion::LLM.provider_supports_embeddings?(provider) }
+
+  context 'with nil' do
+    let(:provider) { nil }
+    it { is_expected.to be(false) }
+  end
+
+  context 'with :ollama' do
+    let(:provider) { :ollama }
+    it 'returns true (hardcoded; Ollama does not go through render_embedding_payload)' do
+      expect(supports?).to be(true)
+    end
+  end
+
+  context 'with :azure' do
+    let(:provider) { :azure }
+    it 'returns true (hardcoded; Azure does not go through render_embedding_payload)' do
+      expect(supports?).to be(true)
+    end
+  end
+
+  context 'with :anthropic' do
+    let(:provider) { :anthropic }
+    it 'returns false — hardcoded because the native Anthropic API has no embedding endpoint' do
+      expect(supports?).to be(false)
+    end
+  end
+
+  context 'with :bedrock' do
+    let(:provider) { :bedrock }
+
+    it 'returns false today — falls through to the NameError branch because the Bedrock provider class has not implemented render_embedding_payload' do
+      # This test pins current behavior: Bedrock is no longer hardcoded-false,
+      # but the instance_method probe raises NameError because the method is
+      # not defined on the Bedrock class. When a sibling contribution adds
+      # render_embedding_payload to lex-bedrock, this expectation should flip
+      # to `be(true)` with no other change required here.
+      expect(supports?).to be(false)
+    end
+  end
+
+  context 'with an unknown provider' do
+    let(:provider) { :does_not_exist }
+    it 'returns false — RubyLLM::Provider.resolve returns nil' do
+      expect(supports?).to be(false)
+    end
+  end
+end

--- a/spec/legion/llm/provider_supports_embeddings_spec.rb
+++ b/spec/legion/llm/provider_supports_embeddings_spec.rb
@@ -3,7 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe 'Legion::LLM.provider_supports_embeddings?' do
-  subject(:supports?) { Legion::LLM.provider_supports_embeddings?(provider) }
+  # `provider_supports_embeddings?` is a private singleton method on Legion::LLM
+  # (declared after the `private` directive inside `class << self`). We call it
+  # via `.send` to bypass visibility — standard Ruby pattern for testing private
+  # methods without changing the public surface.
+  subject(:supports?) { Legion::LLM.send(:provider_supports_embeddings?, provider) }
 
   context 'with nil' do
     let(:provider) { nil }


### PR DESCRIPTION
## Summary

`provider_supports_embeddings?` previously short-circuited with a hardcoded `return false` for both `:anthropic` and `:bedrock`. This PR removes `:bedrock` from that exclusion so the method falls through to the existing reflection-based probe (`klass.instance_method(:render_embedding_payload)`).

**Behavior is byte-identical today**: the probe raises `NameError` (because `lex-bedrock` does not yet implement `render_embedding_payload`) and the method still returns `false` for Bedrock. The hardcoded exclusion was masking a missing implementation, not enforcing an API limitation.

`:anthropic` remains hardcoded-false — Anthropic's native API has no embedding endpoint.

## Motivation

- `PROVIDER_EMBEDDING_MODELS` already ships `bedrock: 'amazon.titan-embed-text-v2:0'`, signalling that Bedrock embedding support is an expected capability.
- In network environments where local model access is unavailable and no alternative cloud embedding provider is configured, Bedrock may be the only reachable embedding option. The hardcoded exclusion silently blocked any future activation path regardless of deployment context.
- Once `lex-bedrock` implements `render_embedding_payload` (tracked in [LegionIO/lex-bedrock#5](https://github.com/LegionIO/lex-bedrock/issues/5)), this provider will be detected as embedding-capable with no further changes required here.

## Changes

- `lib/legion/llm.rb`: remove `:bedrock` from the hardcoded exclusion list; add 3-line comment explaining the rationale
- `spec/legion/llm/provider_supports_embeddings_spec.rb`: new spec covering each provider class
- `lib/legion/llm/version.rb`: 0.7.15 → 0.7.16
- `CHANGELOG.md`: `[0.7.16] - 2026-04-22` Internal section

## Follow-on

LegionIO/lex-bedrock#5 — Implement `render_embedding_payload` for Titan embeddings (the change that will make Bedrock actually return `true` from this probe).

## Test Plan

- `bundle exec rspec spec/legion/llm/provider_supports_embeddings_spec.rb` — all examples pass
- `bundle exec rspec` — full suite green (Ruby 3.4 + 4.0)
- `bundle exec rubocop` — 0 offenses