### PR TITLE
fix: handle BadRequestError + ContextLengthExceededError with provide…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Legion LLM Changelog
 
+## [0.8.17] - 2026-04-22
+
+### Added
+- Audit events now include `system_prompt` (full text sent to provider), `injected_tools` (list of tool names injected), and `identity` (extracted user identity from caller).
+
+### Fixed
+- `tokens` field in audit events was serialized as a `#<data ...>` inspect string instead of a proper hash. Now calls `.to_h` on Data.define objects.
+- `enrichments` in audit events now compacted: array values (e.g. GAIA valence history) reduced to their last element.
+- `timeline` in audit events filtered to only provider, escalation, and tool execution events — diagnostic trace entries (tracing:init, rbac, context:stored, etc.) are stripped.
+
 ## [0.8.16] - 2026-04-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.8.18] - 2026-04-22
+
+### Fixed
+- API caller identity no longer hardcoded as `api:inference`. The inference route now resolves the actual user via `env['legion.principal']` (from Identity::Middleware), `Legion::Identity::Process` (LDAP/Kerberos), or OS username (with email domain stripped). Adds `username` and `hostname` to the `requested_by` hash in audit trails.
+
 ## [0.8.17] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Legion LLM Changelog
 
+## [0.8.16] - 2026-04-22
+
+### Fixed
+- `RubyLLM::BadRequestError` (HTTP 400) and `RubyLLM::ContextLengthExceededError` now trigger the provider fallback-retry chain instead of bubbling up as unhandled 500s. Both `run_provider_call_single` and `step_provider_call_stream` retry on the next available provider before giving up.
+- Resolved provider/model is now logged (`log.info`) in `step_routing` so provider errors can be diagnosed from daemon logs without relying on SSE done events.
+
+### Changed
+- Extracted `try_fallback_or_raise` helper from duplicated retry logic in both rescue chains, reducing the auth/bad-request/context-overflow fallback pattern to a single call each.
+
+## [0.8.15] - 2026-04-22
+
+### Changed
+- **5-tier routing model**: restructured from 3 tiers (local/fleet/cloud) to 5 tiers (local/fleet/openai_compat/cloud/frontier). Anthropic and OpenAI are now `:frontier` (direct API); Bedrock, Azure, Gemini are `:cloud` (managed providers). New `:openai_compat` tier for user-configured OpenAI-spec gateways.
+- `Resolution`: added `frontier?`, `openai_compat?`, and `external?` predicates.
+- `TierAssigner`: `user:*` and critical/high priority requests route to `:frontier` instead of `:cloud`.
+- `GatewayInterceptor`: intercepts both `:cloud` and `:frontier` tiers, preserving original tier.
+- Privacy enforcement (`assert_external_allowed!`) blocks all external tiers (cloud + frontier + openai_compat), not just cloud. `never_cloud` constraint now blocks both `:cloud` and `:frontier`. New `never_external` constraint blocks all three external tiers.
+- `resolve_chain` fallback defaults changed from `:cloud`/`:bedrock` to `:frontier`/`:anthropic`.
+
 ## [0.8.13] - 2026-04-22
 
 ### Fixed

--- a/lib/legion/llm/api/native/helpers.rb
+++ b/lib/legion/llm/api/native/helpers.rb
@@ -326,6 +326,58 @@ module Legion
                 end
               end
 
+              define_method(:resolve_caller_identity) do |rack_env|
+                return rack_env['legion.tenant_id'] if rack_env['legion.tenant_id']
+
+                kerb = begin
+                  Legion::Settings.dig(:kerberos, :username)
+                rescue StandardError
+                  nil
+                end
+                return "user:#{kerb}" if kerb.is_a?(String) && !kerb.empty?
+
+                principal = rack_env['legion.principal']
+                return "user:#{principal.canonical_name}" if principal.respond_to?(:canonical_name) && principal.canonical_name != 'system'
+
+                if defined?(Legion::Identity::Process)
+                  name = Legion::Identity::Process.canonical_name
+                  return "user:#{name}" if name && name != 'anonymous'
+                end
+
+                raw = ENV.fetch('USER', nil) || ENV.fetch('LOGNAME', nil) || 'anonymous'
+                username = raw.include?('@') ? raw.split('@').first : raw
+                "user:#{username}"
+              end
+
+              define_method(:resolve_requested_by) do |rack_env, identity_string|
+                hostname = begin
+                  Legion::Settings[:client][:hostname]
+                rescue StandardError
+                  Socket.gethostname
+                end
+                username = identity_string.delete_prefix('user:')
+
+                kerb = begin
+                  Legion::Settings.dig(:kerberos, :username)
+                rescue StandardError
+                  nil
+                end
+                if kerb.is_a?(String) && !kerb.empty?
+                  return { identity: identity_string, type: :user, credential: :kerberos,
+                           username: kerb, hostname: hostname }
+                end
+
+                principal = rack_env['legion.principal']
+                if principal.respond_to?(:canonical_name) && principal.canonical_name != 'system'
+                  return { identity: identity_string, type: principal.kind || :user,
+                           credential: principal.source || :local,
+                           username: principal.canonical_name, hostname: hostname }
+                end
+
+                { identity: identity_string, type: :user, credential: :local,
+                  username: username, hostname: hostname }
+              end
+
               define_method(:token_value) do |tokens, key|
                 return nil if tokens.nil?
                 return tokens[key] || tokens[key.to_s] if tokens.is_a?(Hash)

--- a/lib/legion/llm/api/native/inference.rb
+++ b/lib/legion/llm/api/native/inference.rb
@@ -42,7 +42,7 @@ module Legion
               tools = raw_tools || []
               validate_tools!(tools) unless tools.empty?
 
-              caller_identity = env['legion.tenant_id'] || 'api:inference'
+              caller_identity = resolve_caller_identity(env)
               last_user = messages.select { |m| (m[:role] || m['role']).to_s == 'user' }.last
               prompt    = (last_user || {})[:content] || (last_user || {})['content'] || ''
 
@@ -79,7 +79,7 @@ module Legion
               server_caller_fields = {
                 source:       'api',
                 path:         request.path,
-                requested_by: { identity: caller_identity, type: :user, credential: :api }
+                requested_by: resolve_requested_by(env, caller_identity)
               }
               effective_caller = server_caller_fields.merge(safe_caller_fields)
               caller_summary = [effective_caller[:source], effective_caller[:path]].compact.join(':')

--- a/lib/legion/llm/inference/audit_publisher.rb
+++ b/lib/legion/llm/inference/audit_publisher.rb
@@ -22,17 +22,22 @@ module Legion
             tc.is_a?(Types::ToolCall) ? tc.to_audit_hash : tc
           end
 
+          audit_data = response.audit || {}
+          provider_payload = audit_data[:provider_payload] || {}
+
           event = {
             request_id:       response.request_id,
             conversation_id:  response.conversation_id,
             caller:           response.caller,
+            identity:         extract_identity(response.caller),
             routing:          response.routing,
-            tokens:           response.tokens,
+            tokens:           serialize_tokens(response.tokens),
             cost:             response.cost,
-            enrichments:      response.enrichments,
-            audit:            response.audit,
-            timeline:         response.timeline,
-            timestamps:       response.timestamps,
+            system_prompt:    provider_payload[:system_prompt],
+            injected_tools:   provider_payload[:injected_tools],
+            enrichments:      compact_enrichments(response.enrichments),
+            audit:            audit_data.except(:provider_payload),
+            timeline:         compact_timeline(response.timeline),
             classification:   response.classification,
             tracing:          response.tracing,
             messages:         request.messages,
@@ -56,6 +61,52 @@ module Legion
         rescue StandardError => e
           handle_exception(e, level: :warn)
           nil
+        end
+
+        def extract_identity(caller)
+          return nil unless caller.is_a?(Hash)
+
+          rb = caller[:requested_by] || caller['requested_by']
+          return nil unless rb.is_a?(Hash)
+
+          {
+            identity:   rb[:identity] || rb['identity'],
+            type:       rb[:type] || rb['type'],
+            credential: rb[:credential] || rb['credential']
+          }.compact
+        end
+
+        def serialize_tokens(tokens)
+          return tokens.to_h if tokens.respond_to?(:to_h) && !tokens.is_a?(Hash)
+          return tokens if tokens.is_a?(Hash)
+
+          {}
+        end
+
+        def compact_enrichments(enrichments)
+          return {} unless enrichments.is_a?(Hash)
+
+          enrichments.transform_values do |v|
+            next v unless v.is_a?(Hash)
+
+            summary = { content: v[:content], timestamp: v[:timestamp] }
+            data = v[:data]
+            next summary unless data.is_a?(Hash)
+
+            compacted = data.transform_values do |dv|
+              dv.is_a?(Array) && dv.size > 1 ? dv.last : dv
+            end
+            summary.merge(data: compacted)
+          end
+        end
+
+        def compact_timeline(timeline)
+          return [] unless timeline.is_a?(Array)
+
+          timeline.select do |event|
+            key = (event[:key] || event['key']).to_s
+            key.start_with?('provider:') || key.start_with?('escalation:') || key.start_with?('tool:execute:')
+          end
         end
 
         def build_message_context(response:, **)

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -692,7 +692,14 @@ module Legion
           session = RubyLLM.chat(**ruby_llm_chat_options)
 
           inject_ruby_llm_tools(session)
-          apply_ruby_llm_instructions(session)
+          system_prompt = apply_ruby_llm_instructions(session)
+
+          @audit[:provider_payload] = {
+            system_prompt:  system_prompt,
+            injected_tools: @injected_tool_map.keys,
+            tool_count:     @injected_tool_map.size,
+            timestamp:      Time.now
+          }
 
           messages = apply_conversation_breakpoint(@request.messages)
           add_ruby_llm_prior_messages(session, messages)
@@ -851,10 +858,12 @@ module Legion
             system:      @request.system,
             enrichments: @enrichments
           )
-          return unless injected_system
+          return nil unless injected_system
 
           system_blocks = apply_cache_control([{ type: :text, content: injected_system }])
-          session.with_instructions(system_blocks.last[:content])
+          final = system_blocks.last[:content]
+          session.with_instructions(final)
+          final
         end
 
         def add_ruby_llm_prior_messages(session, messages)

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -331,6 +331,7 @@ module Legion
           @resolved_provider = provider || Legion::LLM.settings[:default_provider]
           @resolved_model = model || Legion::LLM.settings[:default_model]
 
+          log.info "[llm][inference] resolved provider=#{@resolved_provider} model=#{@resolved_model}"
           @timeline.record(
             category: :audit, key: 'routing:provider_selection',
             direction: :internal, detail: "routed to #{@resolved_provider}:#{@resolved_model}",
@@ -356,38 +357,17 @@ module Legion
             execute_provider_request
           rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError,
                  Faraday::UnauthorizedError, Faraday::ForbiddenError => e
-            providers_tried << @resolved_provider
-            fallback = find_fallback_provider(exclude: providers_tried)
-            handle_exception(
-              e,
-              level:             :warn,
-              operation:         'llm.pipeline.provider_call.auth',
-              provider:          @resolved_provider,
-              model:             @resolved_model,
-              fallback_provider: fallback&.dig(:provider)
-            )
-            if fallback
-              log.warn "[pipeline] #{@resolved_provider} auth failed (#{e.class}), falling back to #{fallback[:provider]}:#{fallback[:model]}"
-              from_provider = @resolved_provider
-              from_model = @resolved_model
-              @resolved_provider = fallback[:provider]
-              @resolved_model = fallback[:model]
-              @warnings << { type: :provider_fallback, original_error: e.message, fallback: "#{@resolved_provider}:#{@resolved_model}" }
-              @tool_event_handler&.call(
-                type: :model_fallback,
-                from_provider: from_provider, to_provider: @resolved_provider,
-                from_model: from_model, to_model: @resolved_model,
-                error: e.message, reason: 'auth_failed'
-              )
-              @timeline.record(
-                category: :provider, key: 'provider:fallback',
-                direction: :internal,
-                detail: "auth failed on #{providers_tried.last}, trying #{@resolved_provider}",
-                from: 'pipeline', to: "provider:#{@resolved_provider}"
-              )
-              retry
-            end
-            raise Legion::LLM::AuthError, e.message
+            try_fallback_or_raise(e, providers_tried, operation: 'provider_call.auth',
+                                                      reason: 'auth_failed', error_class: Legion::LLM::AuthError)
+            retry
+          rescue RubyLLM::ContextLengthExceededError => e
+            try_fallback_or_raise(e, providers_tried, operation: 'provider_call.context_overflow',
+                                                      reason: 'context_overflow', error_class: Legion::LLM::ContextOverflow)
+            retry
+          rescue RubyLLM::BadRequestError => e
+            try_fallback_or_raise(e, providers_tried, operation: 'provider_call.bad_request',
+                                                      reason: 'bad_request', error_class: Legion::LLM::ProviderError)
+            retry
           rescue RubyLLM::RateLimitError => e
             handle_exception(e, level: :warn, operation: 'llm.pipeline.provider_call.rate_limit',
                               provider: @resolved_provider, model: @resolved_model)
@@ -651,33 +631,17 @@ module Legion
             execute_provider_request_stream(&)
           rescue RubyLLM::UnauthorizedError, RubyLLM::ForbiddenError,
                  Faraday::UnauthorizedError, Faraday::ForbiddenError => e
-            providers_tried << @resolved_provider
-            fallback = find_fallback_provider(exclude: providers_tried)
-            handle_exception(
-              e,
-              level:             :warn,
-              operation:         'llm.pipeline.provider_call_stream.auth',
-              provider:          @resolved_provider,
-              model:             @resolved_model,
-              fallback_provider: fallback&.dig(:provider)
-            )
-            if fallback
-              log.warn "[pipeline] #{@resolved_provider} stream auth failed (#{e.class}), " \
-                       "falling back to #{fallback[:provider]}:#{fallback[:model]}"
-              from_provider = @resolved_provider
-              from_model = @resolved_model
-              @resolved_provider = fallback[:provider]
-              @resolved_model = fallback[:model]
-              @warnings << { type: :provider_fallback, original_error: e.message, fallback: "#{@resolved_provider}:#{@resolved_model}" }
-              @tool_event_handler&.call(
-                type: :model_fallback,
-                from_provider: from_provider, to_provider: @resolved_provider,
-                from_model: from_model, to_model: @resolved_model,
-                error: e.message, reason: 'auth_failed'
-              )
-              retry
-            end
-            raise Legion::LLM::AuthError, e.message
+            try_fallback_or_raise(e, providers_tried, operation: 'provider_call_stream.auth',
+                                                      reason: 'auth_failed', error_class: Legion::LLM::AuthError)
+            retry
+          rescue RubyLLM::ContextLengthExceededError => e
+            try_fallback_or_raise(e, providers_tried, operation: 'provider_call_stream.context_overflow',
+                                                      reason: 'context_overflow', error_class: Legion::LLM::ContextOverflow)
+            retry
+          rescue RubyLLM::BadRequestError => e
+            try_fallback_or_raise(e, providers_tried, operation: 'provider_call_stream.bad_request',
+                                                      reason: 'bad_request', error_class: Legion::LLM::ProviderError)
+            retry
           rescue RubyLLM::RateLimitError => e
             handle_exception(e, level: :warn, operation: 'llm.pipeline.provider_call_stream.rate_limit',
                               provider: @resolved_provider, model: @resolved_model)
@@ -965,6 +929,33 @@ module Legion
         rescue StandardError => e
           handle_exception(e, level: :warn, operation: 'llm.pipeline.annotate_top_level_span')
           nil
+        end
+
+        def try_fallback_or_raise(error, providers_tried, operation:, reason:, error_class:)
+          providers_tried << @resolved_provider
+          fallback = find_fallback_provider(exclude: providers_tried)
+          handle_exception(
+            error,
+            level: :warn, operation: "llm.pipeline.#{operation}",
+            provider: @resolved_provider, model: @resolved_model,
+            fallback_provider: fallback&.dig(:provider)
+          )
+          raise error_class, "#{@resolved_provider}:#{@resolved_model} #{reason} — #{error.message}" unless fallback
+
+          log.warn "[pipeline] #{@resolved_provider}:#{@resolved_model} #{reason} (#{error.message}), " \
+                   "falling back to #{fallback[:provider]}:#{fallback[:model]}"
+          from_provider = @resolved_provider
+          from_model = @resolved_model
+          @resolved_provider = fallback[:provider]
+          @resolved_model = fallback[:model]
+          @warnings << { type: :provider_fallback, original_error: error.message,
+                         fallback: "#{@resolved_provider}:#{@resolved_model}" }
+          @tool_event_handler&.call(
+            type: :model_fallback,
+            from_provider: from_provider, to_provider: @resolved_provider,
+            from_model: from_model, to_model: @resolved_model,
+            error: error.message, reason: reason
+          )
         end
 
         def find_fallback_provider(exclude: [])

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.16'
+    VERSION = '0.8.17'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.15'
+    VERSION = '0.8.16'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.17'
+    VERSION = '0.8.18'
   end
 end

--- a/spec/legion/llm/inference/audit_publisher_spec.rb
+++ b/spec/legion/llm/inference/audit_publisher_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Legion::LLM::Inference::AuditPublisher do
       response = Legion::LLM::Inference::Response.build(
         request_id: 'req_abc', conversation_id: 'conv_xyz',
         message: { role: :assistant, content: 'hi' },
-        caller: { requested_by: { identity: 'user:matt', type: :user } }
+        caller: { requested_by: { identity: 'user:matt', type: :user, credential: :api } }
       )
       request = Legion::LLM::Inference::Request.build(
         messages: [{ role: :user, content: 'hello' }]
@@ -19,23 +19,70 @@ RSpec.describe Legion::LLM::Inference::AuditPublisher do
       expect(event[:request_id]).to eq('req_abc')
       expect(event[:conversation_id]).to eq('conv_xyz')
       expect(event[:caller]).to eq(response.caller)
-      expect(event[:tokens]).to eq(response.tokens)
+      expect(event[:identity]).to eq({ identity: 'user:matt', type: :user, credential: :api })
+      expect(event[:tokens]).to be_a(Hash)
       expect(event[:routing]).to eq(response.routing)
       expect(event[:timestamp]).to be_a(Time)
     end
 
-    it 'includes enrichments and timeline in event' do
+    it 'serializes Data.define tokens to a hash' do
+      usage = Data.define(:input_tokens, :output_tokens).new(input_tokens: 100, output_tokens: 20)
+      response = Legion::LLM::Inference::Response.build(
+        request_id: 'r', conversation_id: 'c',
+        message: { role: :assistant, content: 'hi' },
+        tokens: usage
+      )
+      request = Legion::LLM::Inference::Request.build(messages: [])
+
+      event = described_class.build_event(request: request, response: response)
+      expect(event[:tokens]).to be_a(Hash)
+      expect(event[:tokens][:input_tokens]).to eq(100)
+      expect(event[:tokens][:output_tokens]).to eq(20)
+    end
+
+    it 'includes system_prompt and injected_tools from provider_payload audit' do
+      response = Legion::LLM::Inference::Response.build(
+        request_id: 'r', conversation_id: 'c',
+        message: { role: :assistant, content: 'hi' },
+        audit: { provider_payload: { system_prompt: 'You are Legion.', injected_tools: %w[tool_a tool_b], tool_count: 2 } }
+      )
+      request = Legion::LLM::Inference::Request.build(messages: [])
+
+      event = described_class.build_event(request: request, response: response)
+      expect(event[:system_prompt]).to eq('You are Legion.')
+      expect(event[:injected_tools]).to eq(%w[tool_a tool_b])
+      expect(event[:audit]).not_to have_key(:provider_payload)
+    end
+
+    it 'includes compacted enrichments in event' do
       response = Legion::LLM::Inference::Response.build(
         request_id: 'req_abc', conversation_id: 'conv_xyz',
         message: { role: :assistant, content: 'hi' },
-        enrichments: { 'gaia:advisory' => { data: { valence: [0.5] } } },
-        timeline: [{ seq: 1, key: 'test' }]
+        enrichments: { 'gaia:advisory' => { content: 'valence summary', data: { valence: [0.3, 0.5, 0.7] } } }
       )
       request = Legion::LLM::Inference::Request.build(messages: [])
 
       event = described_class.build_event(request: request, response: response)
       expect(event[:enrichments]).to have_key('gaia:advisory')
-      expect(event[:timeline]).not_to be_empty
+      expect(event[:enrichments]['gaia:advisory'][:data][:valence]).to eq(0.7)
+    end
+
+    it 'filters timeline to provider and escalation events only' do
+      response = Legion::LLM::Inference::Response.build(
+        request_id: 'req_abc', conversation_id: 'conv_xyz',
+        message: { role: :assistant, content: 'hi' },
+        timeline: [
+          { seq: 1, key: 'tracing:init' },
+          { seq: 2, key: 'provider:request_sent', detail: 'streaming from bedrock' },
+          { seq: 3, key: 'provider:response_received', detail: 'response received' },
+          { seq: 4, key: 'context:stored' }
+        ]
+      )
+      request = Legion::LLM::Inference::Request.build(messages: [])
+
+      event = described_class.build_event(request: request, response: response)
+      expect(event[:timeline].size).to eq(2)
+      expect(event[:timeline].map { |e| e[:key] }).to eq(%w[provider:request_sent provider:response_received])
     end
 
     it 'includes response_content and messages' do


### PR DESCRIPTION
…r fallback

RubyLLM::BadRequestError (HTTP 400) and ContextLengthExceededError were not caught in the executor rescue chains. Both now trigger the same fallback-retry logic as auth errors — try the next provider before giving up.

Extracted try_fallback_or_raise helper to deduplicate the retry pattern across run_provider_call_single and step_provider_call_stream.

Also added log.info for resolved provider/model in step_routing so provider errors can be diagnosed from daemon logs.

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
