### PR TITLE
fix: emit_event kwargs, file_edit nil guard, tool_limit 50→10 (v0.8.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion LLM Changelog
 
+## [0.8.19] - 2026-04-22
+
+### Fixed
+- `Skills::Base#emit_event` passed a positional Hash to `Legion::Events.emit(**payload)`, causing `ArgumentError` on every skill activation. Now uses keyword splat correctly.
+- `file_edit` client tool crashed with `TypeError: no implicit conversion of nil into String` when the LLM passed nil `old_text`/`new_text`. Now returns an error message to the LLM instead of crashing.
+- `tool_trigger_defaults[:tool_limit]` reduced from 50 to 10 to prevent trigger word matching from injecting dozens of unrelated extension tools on normal user messages.
+
 ## [0.8.18] - 2026-04-22
 
 ### Fixed

--- a/lib/legion/llm/api/native/helpers.rb
+++ b/lib/legion/llm/api/native/helpers.rb
@@ -37,7 +37,7 @@ module Legion
             end
           end
 
-          def dispatch_client_tool(ref, **kwargs) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+          def dispatch_client_tool(ref, **kwargs) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
             case ref
             when 'sh'
               cmd = kwargs[:command] || kwargs[:cmd] || kwargs.values.first.to_s
@@ -55,8 +55,10 @@ module Legion
               path = kwargs[:path] || kwargs[:file_path]
               old_text = kwargs[:old_text] || kwargs[:search]
               new_text = kwargs[:new_text] || kwargs[:replace]
+              return 'file_edit error: old_text is required' if old_text.nil? || old_text.empty?
+
               content = ::File.read(path, encoding: 'utf-8')
-              content.sub!(old_text, new_text)
+              content.sub!(old_text, new_text || '')
               ::File.write(path, content)
               "Edited #{path}"
             when 'list_directory'

--- a/lib/legion/llm/settings.rb
+++ b/lib/legion/llm/settings.rb
@@ -285,7 +285,7 @@ module Legion
       def self.tool_trigger_defaults
         {
           scan_depth: 10,
-          tool_limit: 50
+          tool_limit: 10
         }
       end
 

--- a/lib/legion/llm/skills/base.rb
+++ b/lib/legion/llm/skills/base.rb
@@ -246,7 +246,7 @@ module Legion
         def emit_event(conv_id, event, **payload)
           return unless conv_id
 
-          Legion::Events.emit(event, { conversation_id: conv_id }.merge(payload))
+          Legion::Events.emit(event, conversation_id: conv_id, **payload)
         end
 
         protected

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.18'
+    VERSION = '0.8.19'
   end
 end


### PR DESCRIPTION
- Skills::Base#emit_event: pass keyword args to Events.emit instead of positional Hash (ArgumentError on every skill activation)
- file_edit tool: guard against nil old_text/new_text from LLM (TypeError: no implicit conversion of nil into String)
- tool_trigger_defaults: tool_limit 50→10 to prevent trigger word matching from injecting dozens of unrelated extension tools

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
