### PR TITLE
fix: StructuredOutput prompt fallback passes unknown messages: kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.8.23] - 2026-04-23
+
+### Fixed
+- `Call::StructuredOutput` prompt-fallback path passed `messages:` (plural) to `chat_single` which only accepts `message:` (singular), leaking the unknown kwarg into `RubyLLM::Chat.new`. Visible as repeated "unknown keyword: :messages" warnings during dream cycle contradiction detection. Flattened instruction + messages into a single string via `extract_user_content`.
+
 ## [0.8.22] - 2026-04-22
 
 ### Fixed

--- a/lib/legion/llm/call/structured_output.rb
+++ b/lib/legion/llm/call/structured_output.rb
@@ -36,10 +36,10 @@ module Legion
               instruction = "You MUST respond with valid JSON matching this schema:\n" \
                             "```json\n#{Legion::JSON.dump(schema)}\n```\n" \
                             'Respond with ONLY the JSON object, no other text.'
-              augmented = [{ role: 'system', content: instruction }] + Array(messages)
+              user_content = extract_user_content(messages, instruction)
               Legion::LLM::Inference.send(:chat_single,
                                           model: model, provider: provider, intent: nil, tier: nil,
-                                          messages: augmented, **opts.except(:attempt))
+                                          message: user_content, **opts.except(:attempt))
             end
           end
 
@@ -55,16 +55,25 @@ module Legion
 
           def retry_with_instruction(messages, schema, model, provider: nil, **opts)
             instruction = "Your previous response was not valid JSON. Respond with ONLY a valid JSON object matching this schema:\n#{Legion::JSON.dump(schema)}"
-            augmented = Array(messages) + [{ role: 'user', content: instruction }]
+            user_content = extract_user_content(messages, instruction)
             result = Legion::LLM::Inference.send(:chat_single,
                                                  model: model, provider: provider, intent: nil, tier: nil,
-                                                 messages: augmented, **opts.except(:attempt))
+                                                 message: user_content, **opts.except(:attempt))
 
             parsed = Legion::JSON.load(result[:content])
             { data: parsed, raw: result[:content], model: result[:model], valid: true, retried: true }
           rescue StandardError => e
             handle_exception(e, level: :warn)
             { data: nil, error: e.message, valid: false }
+          end
+
+          def extract_user_content(messages, instruction)
+            parts = [instruction]
+            Array(messages).each do |msg|
+              content = msg[:content] || msg['content']
+              parts << content.to_s unless content.to_s.empty?
+            end
+            parts.join("\n\n")
           end
 
           def supports_response_format?(model)

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.22'
+    VERSION = '0.8.23'
   end
 end


### PR DESCRIPTION
## Summary

- `call_with_schema` and `retry_with_instruction` passed `messages:` (plural array) to `chat_single`, which only accepts `message:` (singular string). The kwarg leaked through to `RubyLLM::Chat.new` which raised `unknown keyword: :messages`.
- Added `extract_user_content` helper that flattens the instruction + message array into a single string, passed as `message:` to `chat_single`.
- Fixes 10x "unknown keyword: :messages" warnings per dream cycle during `knowledge_promotion` → `handle_ingest` → `detect_contradictions` → `llm_detects_conflict?`

## Test plan

- [x] 1970/1970 rspec examples pass
- [x] Rubocop clean
- [ ] Verify contradiction detection works during dream cycle (no more warnings)