### PR TITLE
feat: 5-tier routing, audit/metering coverage, identity, error handling (v0.8.15–0.8.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Legion LLM Changelog
 
+## [0.8.24] - 2026-04-23
+
+### Fixed
+- All AMQP transport messages (audit, metering, tool, escalation) now include identity headers (`x-legion-identity`, `x-legion-credential`, `x-legion-hostname`) extracted from the `caller` field. Previously only prompt audit events carried identity in the body — tool audit and metering messages had no identity at all.
+- Embedding metering events now include `caller` context.
+- Non-pipeline `chat_single` metering events now include `caller` context from kwargs.
+
 ## [0.8.23] - 2026-04-23
 
 ### Fixed
 - `Call::StructuredOutput` prompt-fallback path passed `messages:` (plural) to `chat_single` which only accepts `message:` (singular), leaking the unknown kwarg into `RubyLLM::Chat.new`. Visible as repeated "unknown keyword: :messages" warnings during dream cycle contradiction detection. Flattened instruction + messages into a single string via `extract_user_content`.
-- All AMQP transport messages (audit, metering, tool, escalation) now include identity headers (`x-legion-identity`, `x-legion-credential`, `x-legion-hostname`) extracted from the `caller` field. Previously only prompt audit events carried identity in the body — tool audit and metering messages had no identity at all.
-- Embedding metering events now include `caller` context.
-- Non-pipeline `chat_single` metering events now include `caller` context from kwargs.
 
 ## [0.8.22] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 - `Call::StructuredOutput` prompt-fallback path passed `messages:` (plural) to `chat_single` which only accepts `message:` (singular), leaking the unknown kwarg into `RubyLLM::Chat.new`. Visible as repeated "unknown keyword: :messages" warnings during dream cycle contradiction detection. Flattened instruction + messages into a single string via `extract_user_content`.
+- All AMQP transport messages (audit, metering, tool, escalation) now include identity headers (`x-legion-identity`, `x-legion-credential`, `x-legion-hostname`) extracted from the `caller` field. Previously only prompt audit events carried identity in the body — tool audit and metering messages had no identity at all.
+- Embedding metering events now include `caller` context.
+- Non-pipeline `chat_single` metering events now include `caller` context from kwargs.
 
 ## [0.8.22] - 2026-04-22
 

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -462,9 +462,15 @@ module Legion
           end
 
           def emit_embedding_metering(provider:, model:, tokens:)
+            caller = begin
+              Legion::LLM.settings[:caller]
+            rescue StandardError
+              nil
+            end
             Legion::LLM::Metering.emit(
               provider: provider, model_id: model, request_type: 'embed',
-              tier: 'cloud', input_tokens: tokens.to_i, output_tokens: 0, total_tokens: tokens.to_i
+              tier: 'cloud', input_tokens: tokens.to_i, output_tokens: 0, total_tokens: tokens.to_i,
+              caller: caller
             )
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'llm.embeddings.metering')

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -464,7 +464,8 @@ module Legion
           def emit_embedding_metering(provider:, model:, tokens:)
             caller = begin
               Legion::LLM.settings[:caller]
-            rescue StandardError
+            rescue StandardError => e
+              handle_exception(e, level: :debug, operation: 'llm.embeddings.metering.caller')
               nil
             end
             Legion::LLM::Metering.emit(

--- a/lib/legion/llm/inference.rb
+++ b/lib/legion/llm/inference.rb
@@ -514,7 +514,7 @@ module Legion
         log.debug '[llm][inference] chat_single asking session'
         response = block ? session.ask(message, &block) : session.ask(message)
         log.debug "[llm][inference] chat_single response_class=#{response.class} response_nil=#{response.nil?}"
-        emit_non_pipeline_metering(response, model: opts[:model], provider: opts[:provider])
+        emit_non_pipeline_metering(response, model: opts[:model], provider: opts[:provider], caller: kwargs[:caller])
 
         if response && !block && defined?(Quality::ShadowEval) && Quality::ShadowEval.enabled?
           msgs = session.respond_to?(:messages) ? session.messages : nil
@@ -712,14 +712,15 @@ module Legion
         esc.fetch(:quality_threshold, 50)
       end
 
-      def emit_non_pipeline_metering(response, model:, provider:)
+      def emit_non_pipeline_metering(response, model:, provider:, caller: nil)
         return unless response
 
         input  = response.respond_to?(:input_tokens)  ? response.input_tokens.to_i  : 0
         output = response.respond_to?(:output_tokens) ? response.output_tokens.to_i : 0
         Legion::LLM::Metering.emit(
           provider: provider, model_id: model, request_type: 'chat',
-          tier: 'direct', input_tokens: input, output_tokens: output, total_tokens: input + output
+          tier: 'direct', input_tokens: input, output_tokens: output, total_tokens: input + output,
+          caller: caller
         )
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'llm.inference.non_pipeline_metering')

--- a/lib/legion/llm/transport/message.rb
+++ b/lib/legion/llm/transport/message.rb
@@ -65,6 +65,19 @@ module Legion
           h['x-legion-llm-model']          = model_val.to_s                     if model_val
           h['x-legion-llm-request-type']   = @options[:request_type].to_s       if @options[:request_type]
           h['x-legion-llm-schema-version'] = '1.0.0'
+          h.merge(identity_headers)
+        end
+
+        def identity_headers
+          caller = @options[:caller]
+          return {} unless caller.is_a?(Hash)
+
+          rb = caller[:requested_by] || caller['requested_by'] || {}
+          h = {}
+          identity = rb[:identity] || rb['identity'] || rb[:username] || rb['username']
+          h['x-legion-identity']   = identity.to_s   if identity
+          h['x-legion-credential'] = (rb[:credential] || rb['credential']).to_s if rb[:credential] || rb['credential']
+          h['x-legion-hostname']   = (rb[:hostname] || rb['hostname']).to_s     if rb[:hostname] || rb['hostname']
           h
         end
 

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.23'
+    VERSION = '0.8.24'
   end
 end


### PR DESCRIPTION
## Summary

- **5-tier routing model** (v0.8.15): Restructured from 3 tiers (local/fleet/cloud) to 5 tiers (local/fleet/openai_compat/cloud/frontier). Anthropic/OpenAI are `:frontier`, Bedrock/Azure/Gemini are `:cloud`, new `:openai_compat` for user-configured gateways.
- **Error handling** (v0.8.16): `BadRequestError` and `ContextLengthExceededError` now trigger provider fallback-retry instead of bubbling as unhandled 500s.
- **Audit enrichment** (v0.8.17): Audit events include `system_prompt`, `injected_tools`, `identity`. Tokens serialized properly. Enrichments compacted. Timeline filtered.
- **User identity** (v0.8.18): API caller identity resolved from kerberos settings, Identity::Middleware, or OS username — no more hardcoded `api:inference`.
- **Bug fixes** (v0.8.19–0.8.20): Skills `emit_event` kwargs fix, `file_edit` nil guard, tool_limit tuning.
- **Tool audit wiring** (v0.8.21): `Audit.emit_tools` now actually called after tool execution. Metering routing key fixed.
- **Comprehensive audit/metering coverage** (v0.8.22): Error paths (rate limit, provider error, provider down, escalation exhausted, privacy blocks) all emit audit events. Embeddings metered. Non-pipeline chat metered. Caller identity on all metering events.
- **Identity on all AMQP messages** (v0.8.23): `x-legion-identity`, `x-legion-credential`, `x-legion-hostname` headers on every transport message.

## Test plan

- [ ] `bundle exec rspec` — 1970 examples, 0 failures
- [ ] `bundle exec rubocop` — 0 offenses
- [ ] Verify `llm.audit.prompts` queue receives messages with `identity` field and `system_prompt`
- [ ] Verify `llm.audit.tools` queue receives messages after tool execution
- [ ] Verify `llm.metering.write` queue receives messages with `caller` and `request_id`
- [ ] Verify AMQP message headers include `x-legion-identity`
- [ ] Verify privacy mode blocks emit `status: 'privacy_blocked'` audit event
- [ ] Verify provider errors emit audit before re-raising
- [ ] Verify `user:miverso2` appears as identity (from kerberos settings)