### PR TITLE
fix: normalize embedding vectors for providers that unwrap single-inp…

### DIFF
--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -27,7 +27,8 @@ module Legion
 
             response = RubyLLM.embed(text, **build_opts(model, provider, dimensions))
             emit_embedding_metering(provider: provider, model: model, tokens: response.input_tokens)
-            vector = apply_dimension_enforcement(response.vectors.first, provider)
+            vector = normalize_vectors_first(response.vectors)
+            vector = apply_dimension_enforcement(vector, provider)
             return dimension_error(model, provider, vector) if vector.is_a?(String)
 
             { vector: vector, model: model, provider: provider, dimensions: vector&.size || 0, tokens: response.input_tokens }
@@ -99,6 +100,16 @@ module Legion
             opts[:provider]   = provider if provider
             opts[:dimensions] = target_dim if target_dim && provider&.to_sym == :openai
             opts
+          end
+
+          def normalize_vectors_first(vectors)
+            return nil if vectors.nil? || (vectors.is_a?(Array) && vectors.empty?)
+
+            first = vectors.first
+            return first if first.is_a?(Array)
+            return vectors if vectors.is_a?(Array) && vectors.first.is_a?(Numeric)
+
+            first
           end
 
           def apply_dimension_enforcement(vector, provider)

--- a/spec/legion/llm/embeddings_spec.rb
+++ b/spec/legion/llm/embeddings_spec.rb
@@ -265,6 +265,16 @@ RSpec.describe Legion::LLM::Embeddings do
       expect(result[:provider]).to eq(:openai)
     end
 
+    it 'handles unwrapped vectors from providers that flatten single-input results' do
+      flat_response = double(vectors: Array.new(1024, 0.1), input_tokens: 5)
+      allow(RubyLLM).to receive(:embed).and_return(flat_response)
+
+      result = described_class.generate(text: 'test')
+      expect(result[:vector]).to be_a(Array)
+      expect(result[:vector].size).to eq(1024)
+      expect(result[:dimensions]).to eq(1024)
+    end
+
     it 'resolves provider from llm settings when not specified' do
       allow(Legion::Settings).to receive(:dig).with(:llm, :default_provider).and_return(:bedrock)
       allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(nil)


### PR DESCRIPTION
…ut results

RubyLLM's OpenAI provider unwraps single-input embedding responses (vectors becomes [0.007, ...] instead of [[0.007, ...]]). This caused NoMethodError on .size when the code assumed vectors.first was always an Array. Normalize at the legion-llm layer so we're resilient to any upstream provider behavior.

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
