### PR TITLE
fix: handle RubyLLM::Message in StructuredOutput response access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - `StructuredOutput.generate`, `handle_parse_error`, and `retry_with_instruction` used hash-style access (`result[:content]`, `result[:model]`) on the return value of `chat_single`, but `chat_single` returns a `RubyLLM::Message` object which only supports method access (`.content`, `.model_id`). All four access sites now use `respond_to?` duck-typing so both hash and Message objects work. Visible as `undefined method '[]' for an instance of RubyLLM::Message` in Apollo's `llm_detects_conflict?` and any structured output caller using non-schema-capable models (e.g. ollama/qwen).
+- `Call::Embeddings.generate` crashed with `NoMethodError` on `.size` when `response.vectors` was a flat array (`[0.007, ...]`) instead of nested (`[[0.007, ...]]`). RubyLLM's OpenAI provider unwraps single-input embedding responses. Added `normalize_vectors_first` to detect and handle both flat and nested vector formats before dimension enforcement.
 
 ## [0.8.24] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.8.25] - 2026-04-24
+
+### Fixed
+- `StructuredOutput.generate`, `handle_parse_error`, and `retry_with_instruction` used hash-style access (`result[:content]`, `result[:model]`) on the return value of `chat_single`, but `chat_single` returns a `RubyLLM::Message` object which only supports method access (`.content`, `.model_id`). All four access sites now use `respond_to?` duck-typing so both hash and Message objects work. Visible as `undefined method '[]' for an instance of RubyLLM::Message` in Apollo's `llm_detects_conflict?` and any structured output caller using non-schema-capable models (e.g. ollama/qwen).
+
 ## [0.8.24] - 2026-04-23
 
 ### Fixed

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -27,7 +27,8 @@ module Legion
 
             response = RubyLLM.embed(text, **build_opts(model, provider, dimensions))
             emit_embedding_metering(provider: provider, model: model, tokens: response.input_tokens)
-            vector = apply_dimension_enforcement(response.vectors.first, provider)
+            vector = normalize_vectors_first(response.vectors)
+            vector = apply_dimension_enforcement(vector, provider)
             return dimension_error(model, provider, vector) if vector.is_a?(String)
 
             { vector: vector, model: model, provider: provider, dimensions: vector&.size || 0, tokens: response.input_tokens }
@@ -99,6 +100,16 @@ module Legion
             opts[:provider]   = provider if provider
             opts[:dimensions] = target_dim if target_dim && provider&.to_sym == :openai
             opts
+          end
+
+          def normalize_vectors_first(vectors)
+            return nil if vectors.nil? || (vectors.is_a?(Array) && vectors.empty?)
+
+            first = vectors.first
+            return first if first.is_a?(Array)
+            return vectors if vectors.is_a?(Array) && vectors.first.is_a?(Numeric)
+
+            first
           end
 
           def apply_dimension_enforcement(vector, provider)

--- a/lib/legion/llm/call/structured_output.rb
+++ b/lib/legion/llm/call/structured_output.rb
@@ -15,8 +15,11 @@ module Legion
             result = call_with_schema(messages, schema, model, provider: provider, **)
             log.info "[llm][structured_output] model=#{model} provider=#{provider} valid=true"
 
-            parsed = Legion::JSON.load(result[:content])
-            { data: parsed, raw: result[:content], model: result[:model], valid: true }
+            content = result.respond_to?(:content) ? result.content : result[:content]
+            raw_model = result.respond_to?(:model_id) ? result.model_id : result[:model]
+
+            parsed = Legion::JSON.load(content)
+            { data: parsed, raw: content, model: raw_model, valid: true }
           rescue ::JSON::ParserError => e
             log.warn "[llm][structured_output] model=#{model} provider=#{provider} parse_error=#{e.message}"
             handle_parse_error(e, messages, schema, model, provider, result, **)
@@ -49,7 +52,8 @@ module Legion
             if retry_enabled? && attempt < max_retries
               retry_with_instruction(messages, schema, model, provider: provider, attempt: attempt + 1, **opts)
             else
-              { data: nil, error: "JSON parse failed: #{error.message}", raw: result&.dig(:content), valid: false }
+              raw = result.respond_to?(:content) ? result&.content : result&.dig(:content)
+              { data: nil, error: "JSON parse failed: #{error.message}", raw: raw, valid: false }
             end
           end
 
@@ -60,8 +64,11 @@ module Legion
                                                  model: model, provider: provider, intent: nil, tier: nil,
                                                  message: user_content, **opts.except(:attempt))
 
-            parsed = Legion::JSON.load(result[:content])
-            { data: parsed, raw: result[:content], model: result[:model], valid: true, retried: true }
+            retry_content = result.respond_to?(:content) ? result.content : result[:content]
+            retry_model = result.respond_to?(:model_id) ? result.model_id : result[:model]
+
+            parsed = Legion::JSON.load(retry_content)
+            { data: parsed, raw: retry_content, model: retry_model, valid: true, retried: true }
           rescue StandardError => e
             handle_exception(e, level: :warn)
             { data: nil, error: e.message, valid: false }

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.24'
+    VERSION = '0.8.25'
   end
 end

--- a/spec/legion/llm/embeddings_spec.rb
+++ b/spec/legion/llm/embeddings_spec.rb
@@ -265,6 +265,16 @@ RSpec.describe Legion::LLM::Embeddings do
       expect(result[:provider]).to eq(:openai)
     end
 
+    it 'handles unwrapped vectors from providers that flatten single-input results' do
+      flat_response = double(vectors: Array.new(1024, 0.1), input_tokens: 5)
+      allow(RubyLLM).to receive(:embed).and_return(flat_response)
+
+      result = described_class.generate(text: 'test')
+      expect(result[:vector]).to be_a(Array)
+      expect(result[:vector].size).to eq(1024)
+      expect(result[:dimensions]).to eq(1024)
+    end
+
     it 'resolves provider from llm settings when not specified' do
       allow(Legion::Settings).to receive(:dig).with(:llm, :default_provider).and_return(:bedrock)
       allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(nil)

--- a/spec/legion/llm/structured_output_spec.rb
+++ b/spec/legion/llm/structured_output_spec.rb
@@ -22,6 +22,8 @@ end
 
 require 'legion/llm/call/structured_output'
 
+RubyLLMMessage = Struct.new(:content, :model_id, keyword_init: true)
+
 RSpec.describe Legion::LLM::Call::StructuredOutput do
   let(:schema) { { type: 'object', properties: { name: { type: 'string' } } } }
   let(:messages) { [{ role: 'user', content: 'Give me a name' }] }
@@ -36,6 +38,19 @@ RSpec.describe Legion::LLM::Call::StructuredOutput do
       result = described_class.generate(messages: messages, schema: schema, model: 'gpt-4o')
       expect(result[:valid]).to be true
       expect(result[:data]).to eq({ name: 'Alice' })
+    end
+
+    it 'handles RubyLLM::Message objects returned by chat_single' do
+      json_string = '{"name":"Alice"}'
+      msg = RubyLLMMessage.new(content: json_string, model_id: 'qwen3.6:27b-q4_K_M')
+      allow(Legion::LLM::Inference).to receive(:send).with(:chat_single, anything).and_return(msg)
+      allow(Legion::JSON).to receive(:load).with(json_string).and_return({ name: 'Alice' })
+      allow(Legion::JSON).to receive(:dump).and_return('{}')
+
+      result = described_class.generate(messages: messages, schema: schema, model: 'qwen3.6:27b-q4_K_M')
+      expect(result[:valid]).to be true
+      expect(result[:data]).to eq({ name: 'Alice' })
+      expect(result[:model]).to eq('qwen3.6:27b-q4_K_M')
     end
 
     it 'passes provider through to chat_single' do


### PR DESCRIPTION
## Summary
- `StructuredOutput.generate` used hash-style access (`result[:content]`, `result[:model]`) on the return value of `chat_single`, but `chat_single` returns a `RubyLLM::Message` object which only supports method access (`.content`, `.model_id`)
- This caused `undefined method '[]' for an instance of RubyLLM::Message` errors in Apollo's `llm_detects_conflict?` and any structured output caller using non-schema-capable models (e.g. ollama/qwen)
- Fixed all 4 access sites in `generate`, `handle_parse_error`, and `retry_with_instruction` to use `respond_to?` duck-typing so both hash and Message objects work
- Added spec covering the RubyLLM::Message return path

## Test plan
- [x] Existing 6 specs pass (hash-based stubs still work via fallback path)
- [x] New spec verifies Message-object return path parses correctly
- [x] Rubocop clean
- [ ] Deploy and verify Apollo `llm_detects_conflict?` WARN logs stop