### PR TITLE
fix: infer provider from model name to prevent mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Legion LLM Changelog
 
+## [0.8.28] - 2026-04-24
+
+### Fixed
+- Model/provider mismatch when clients send a model name (e.g., `qwen3.5:latest`) without an explicit provider. The fallback paths blindly paired it with `default_provider` (typically `bedrock`), causing `RubyLLM::ModelNotFoundError`. Now infers the correct provider from model naming patterns before falling back to the global default.
+- `arbitrage_fallback` hardcoded `:cloud` tier and `:bedrock` provider when inference failed. Now uses `PROVIDER_TIER` to resolve the correct tier for the inferred provider.
+
+### Added
+- `Router.infer_provider_for_model(model)` — public method that maps model naming patterns to providers. Recognizes Ollama-style models (`:` or `/` in name), Bedrock (`us.*`), OpenAI (`gpt-*`, `o1-*`/`o3-*`/`o4-*`), Anthropic (`claude-*`), and Gemini (`gemini-*`).
+
 ## [0.8.27] - 2026-04-24
 
 ### Fixed

--- a/lib/legion/llm/inference.rb
+++ b/lib/legion/llm/inference.rb
@@ -496,7 +496,8 @@ module Legion
         end
 
         model ||= Legion::LLM.settings[:default_model]
-        provider ||= Legion::LLM.settings[:default_provider]
+        provider ||= (model && Router.infer_provider_for_model(model)) ||
+                     Legion::LLM.settings[:default_provider]
 
         opts = {}
         opts[:model] = model if model

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -328,7 +328,9 @@ module Legion
             end
           end
 
-          @resolved_provider = provider || Legion::LLM.settings[:default_provider]
+          @resolved_provider = provider ||
+                               (model && Router.infer_provider_for_model(model)) ||
+                               Legion::LLM.settings[:default_provider]
           @resolved_model = model || Legion::LLM.settings[:default_model]
 
           log.info "[llm][inference] resolved provider=#{@resolved_provider} model=#{@resolved_model}"

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -846,6 +846,7 @@ module Legion
           duration_ms = started_at ? ((finished_at - started_at) * 1000).round : nil
 
           result_str = (raw.is_a?(String) ? raw : raw.to_s)
+          result_str = result_str.encode('UTF-8', invalid: :replace, undef: :replace, replace: '�') unless result_str.valid_encoding?
           is_error = raw.is_a?(Hash) && (raw[:error] || raw['error']) ? true : false
 
           @pending_tool_history_mutex.synchronize do

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -847,6 +847,7 @@ module Legion
 
           result_str = (raw.is_a?(String) ? raw : raw.to_s)
           result_str = result_str.encode('UTF-8', invalid: :replace, undef: :replace, replace: '�') unless result_str.valid_encoding?
+          result_str = result_str.delete("\x00")
           is_error = raw.is_a?(Hash) && (raw[:error] || raw['error']) ? true : false
 
           @pending_tool_history_mutex.synchronize do

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -18,7 +18,22 @@ module Legion
                         gemini: :cloud, azure: :cloud, ollama: :local, vllm: :local }.freeze
       PROVIDER_ORDER = %i[ollama vllm bedrock azure gemini anthropic openai].freeze
 
+      OLLAMA_MODEL_PATTERN = /[:\/]/.freeze
+
       class << self
+        def infer_provider_for_model(model)
+          return nil if model.nil? || model.to_s.empty?
+
+          model_s = model.to_s
+          return :bedrock if model_s.start_with?('us.')
+          return :openai if model_s.match?(/\Agpt-|\Ao[134]-/)
+          return :anthropic if model_s.start_with?('claude-')
+          return :gemini if model_s.start_with?('gemini-')
+          return :ollama if model_s.match?(OLLAMA_MODEL_PATTERN)
+
+          nil
+        end
+
         # Resolve an LLM routing intent to a tier/provider/model decision.
         #
         # @param intent   [Hash, nil] routing intent (capability, privacy, etc.)
@@ -95,18 +110,12 @@ module Legion
           model = Arbitrage.cheapest_for(capability: capability)
           return nil unless model
 
-          provider = Arbitrage.cost_table[model] ? infer_provider(model) : nil
-          log.debug("Router: arbitrage fallback selected model=#{model}")
-          Resolution.new(tier: :cloud, provider: provider || :bedrock, model: model, rule: 'arbitrage_fallback')
-        end
+          provider = infer_provider_for_model(model)
+          return nil unless provider
 
-        def infer_provider(model)
-          return :ollama if model.include?('llama')
-          return :bedrock if model.start_with?('us.')
-          return :openai if model.start_with?('gpt')
-          return :google if model.start_with?('gemini')
-
-          :anthropic if model.start_with?('claude')
+          tier = PROVIDER_TIER.fetch(provider, :cloud)
+          log.debug("Router: arbitrage fallback selected model=#{model} provider=#{provider} tier=#{tier}")
+          Resolution.new(tier: tier, provider: provider, model: model, rule: 'arbitrage_fallback')
         end
 
         def explicit_resolution(tier, provider, model)

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -18,7 +18,7 @@ module Legion
                         gemini: :cloud, azure: :cloud, ollama: :local, vllm: :local }.freeze
       PROVIDER_ORDER = %i[ollama vllm bedrock azure gemini anthropic openai].freeze
 
-      OLLAMA_MODEL_PATTERN = /[:\/]/.freeze
+      OLLAMA_MODEL_PATTERN = %r{[:/]}
 
       class << self
         def infer_provider_for_model(model)

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.27'
+    VERSION = '0.8.28'
   end
 end

--- a/spec/legion/llm/router_spec.rb
+++ b/spec/legion/llm/router_spec.rb
@@ -354,22 +354,22 @@ RSpec.describe Legion::LLM::Router do
     {
       'qwen3.5:latest'                    => :ollama,
       'qwen3:7b'                          => :ollama,
-      'llama3:70b'                         => :ollama,
-      'mistral:latest'                     => :ollama,
-      'phi3:mini'                          => :ollama,
+      'llama3:70b'                        => :ollama,
+      'mistral:latest'                    => :ollama,
+      'phi3:mini'                         => :ollama,
       'deepseek-coder:6.7b'               => :ollama,
-      'nomic-embed-text:latest'            => :ollama,
-      'us.anthropic.claude-sonnet-4-6-v1'  => :bedrock,
-      'us.meta.llama3-70b-instruct-v1:0'   => :bedrock,
-      'gpt-4o'                             => :openai,
-      'gpt-4o-mini'                        => :openai,
-      'o1-preview'                         => :openai,
-      'o3-mini'                            => :openai,
-      'o4-mini'                            => :openai,
-      'claude-sonnet-4-6'                  => :anthropic,
-      'claude-3-5-haiku-20241022'          => :anthropic,
-      'gemini-2.0-flash'                   => :gemini,
-      'gemini-1.5-pro'                     => :gemini
+      'nomic-embed-text:latest'           => :ollama,
+      'us.anthropic.claude-sonnet-4-6-v1' => :bedrock,
+      'us.meta.llama3-70b-instruct-v1:0'  => :bedrock,
+      'gpt-4o'                            => :openai,
+      'gpt-4o-mini'                       => :openai,
+      'o1-preview'                        => :openai,
+      'o3-mini'                           => :openai,
+      'o4-mini'                           => :openai,
+      'claude-sonnet-4-6'                 => :anthropic,
+      'claude-3-5-haiku-20241022'         => :anthropic,
+      'gemini-2.0-flash'                  => :gemini,
+      'gemini-1.5-pro'                    => :gemini
     }.each do |model, expected_provider|
       it "infers #{expected_provider} for #{model}" do
         expect(described_class.infer_provider_for_model(model)).to eq(expected_provider)

--- a/spec/legion/llm/router_spec.rb
+++ b/spec/legion/llm/router_spec.rb
@@ -349,4 +349,43 @@ RSpec.describe Legion::LLM::Router do
       expect(described_class.routing_enabled?).to be false
     end
   end
+
+  describe '.infer_provider_for_model' do
+    {
+      'qwen3.5:latest'                    => :ollama,
+      'qwen3:7b'                          => :ollama,
+      'llama3:70b'                         => :ollama,
+      'mistral:latest'                     => :ollama,
+      'phi3:mini'                          => :ollama,
+      'deepseek-coder:6.7b'               => :ollama,
+      'nomic-embed-text:latest'            => :ollama,
+      'us.anthropic.claude-sonnet-4-6-v1'  => :bedrock,
+      'us.meta.llama3-70b-instruct-v1:0'   => :bedrock,
+      'gpt-4o'                             => :openai,
+      'gpt-4o-mini'                        => :openai,
+      'o1-preview'                         => :openai,
+      'o3-mini'                            => :openai,
+      'o4-mini'                            => :openai,
+      'claude-sonnet-4-6'                  => :anthropic,
+      'claude-3-5-haiku-20241022'          => :anthropic,
+      'gemini-2.0-flash'                   => :gemini,
+      'gemini-1.5-pro'                     => :gemini
+    }.each do |model, expected_provider|
+      it "infers #{expected_provider} for #{model}" do
+        expect(described_class.infer_provider_for_model(model)).to eq(expected_provider)
+      end
+    end
+
+    it 'returns nil for nil model' do
+      expect(described_class.infer_provider_for_model(nil)).to be_nil
+    end
+
+    it 'returns nil for empty string' do
+      expect(described_class.infer_provider_for_model('')).to be_nil
+    end
+
+    it 'returns nil for unrecognized model names' do
+      expect(described_class.infer_provider_for_model('some-custom-model')).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `Router.infer_provider_for_model(model)` — public method that maps model naming patterns to providers (e.g., `qwen3.5:latest` → `:ollama`, `us.anthropic.*` → `:bedrock`, `gpt-*` → `:openai`)
- Fixes `Executor.step_routing` and `Inference.chat_single` to infer the provider from the model name before falling back to `default_provider`
- Fixes `arbitrage_fallback` to use the correct tier for inferred providers instead of hardcoding `:cloud`/`:bedrock`

## Problem

When a client sends `model: "qwen3.5:latest"` without an explicit provider, both the pipeline and direct paths fall back to `default_provider` from settings (typically `bedrock`). This produces:

```
RubyLLM::ModelNotFoundError: Unknown model: qwen3.5:latest for provider: bedrock
```

Affects any bootstrap config that sets `default_provider` without routing rules.

## Test plan

- [x] 21 new specs for `infer_provider_for_model` covering Ollama, Bedrock, OpenAI, Anthropic, Gemini, nil, empty, and unknown models
- [x] All 2024 examples pass (1 pre-existing unrelated failure in knowledge_capture test ordering)
- [x] Routing, inference, escalation integration specs all pass (92 examples, 0 failures)