### PR TITLE
[codex] Fix embedding provider routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+*.gem
 /_yardoc/
 /coverage/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.8.31] - 2026-04-27
+
+### Fixed
+- Embedding calls no longer inherit the chat `llm.default_provider`, preventing vLLM or other chat defaults from receiving embedding traffic unless explicitly configured for embeddings. Fixes #104
+
 ## [0.8.30] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.8.32] - 2026-04-27
+
+### Fixed
+- Embedding calls now return a clear unavailable-provider error when no embedding provider is configured or detected, preventing RubyLLM from implicitly selecting a chat/default provider.
+
 ## [0.8.31] - 2026-04-27
 
 ### Fixed

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -14,6 +14,7 @@ module Legion
             return { vector: nil, model: model, provider: provider, error: 'LLM not started' } unless LLM.started?
 
             provider ||= resolve_provider
+            return embedding_unavailable_result(model, provider) unless provider
             return { vector: nil, model: model, provider: provider, error: "provider #{provider} is disabled" } if provider_disabled?(provider)
 
             model ||= resolve_model(provider)
@@ -41,6 +42,8 @@ module Legion
             return texts.map { |_| { vector: nil, error: 'LLM not started' } } unless LLM.started?
 
             provider ||= resolve_provider
+            return unavailable_batch_result(texts, provider, model) unless provider
+
             disabled_result = disabled_batch_result(texts, provider, model)
             return disabled_result if disabled_result
 
@@ -71,6 +74,16 @@ module Legion
             model ||= resolve_model(provider)
             texts.each_with_index.map do |_, i|
               { vector: nil, model: model, provider: provider, dimensions: 0, index: i, error: "provider #{provider} is disabled" }
+            end
+          end
+
+          def embedding_unavailable_result(model, provider)
+            { vector: nil, model: model, provider: provider, error: 'No embedding provider configured' }
+          end
+
+          def unavailable_batch_result(texts, provider, model)
+            texts.each_with_index.map do |_, i|
+              embedding_unavailable_result(model, provider).merge(dimensions: 0, index: i)
             end
           end
 

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -176,7 +176,7 @@ module Legion
             configured = embedding_settings[:provider]
             return configured&.to_sym if configured
 
-            Legion::Settings.dig(:llm, :default_provider)&.to_sym
+            nil
           rescue StandardError => e
             handle_exception(e, level: :debug, operation: 'llm.embeddings.resolve_provider')
             nil

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.31'
+    VERSION = '0.8.32'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.30'
+    VERSION = '0.8.31'
   end
 end

--- a/spec/legion/llm/embeddings_spec.rb
+++ b/spec/legion/llm/embeddings_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe Legion::LLM::Embeddings do
       expect(result[:dimensions]).to eq(1024)
     end
 
-    it 'resolves provider from llm settings when not specified' do
+    it 'does not resolve provider from chat default_provider when not specified' do
       allow(Legion::Settings).to receive(:dig).with(:llm, :default_provider).and_return(:bedrock)
       allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(nil)
 
@@ -303,7 +303,18 @@ RSpec.describe Legion::LLM::Embeddings do
       allow(RubyLLM).to receive(:embed).and_return(mock_response)
 
       result = described_class.generate(text: 'test')
-      expect(result[:provider]).to eq(:bedrock)
+      expect(result[:provider]).to be_nil
+    end
+
+    it 'does not route embeddings to vllm when vllm is the chat default provider' do
+      allow(Legion::Settings).to receive(:dig).with(:llm, :default_provider).and_return(:vllm)
+      allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(nil)
+
+      mock_response = double(vectors: [Array.new(1024, 0.1)], input_tokens: 1)
+      expect(RubyLLM).to receive(:embed).with('test', hash_excluding(provider: :vllm)).and_return(mock_response)
+
+      result = described_class.generate(text: 'test')
+      expect(result[:provider]).to be_nil
     end
   end
 
@@ -335,7 +346,6 @@ RSpec.describe Legion::LLM::Embeddings do
       allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(
         { provider_models: { bedrock: 'amazon.titan-embed-text-v2:0' } }
       )
-      allow(Legion::Settings).to receive(:dig).with(:llm, :default_provider).and_return(:bedrock)
       Legion::LLM.instance_variable_set(:@embedding_provider, :bedrock)
       Legion::LLM.instance_variable_set(:@embedding_model, 'amazon.titan-embed-text-v2:0')
       expect(described_class.default_model).to eq('amazon.titan-embed-text-v2:0')

--- a/spec/legion/llm/embeddings_spec.rb
+++ b/spec/legion/llm/embeddings_spec.rb
@@ -235,8 +235,8 @@ RSpec.describe Legion::LLM::Embeddings do
   before do
     allow(Legion::Settings).to receive(:dig).and_return(nil)
     Legion::LLM.instance_variable_set(:@can_embed, nil)
-    Legion::LLM.instance_variable_set(:@embedding_provider, nil)
-    Legion::LLM.instance_variable_set(:@embedding_model, nil)
+    Legion::LLM.instance_variable_set(:@embedding_provider, :openai)
+    Legion::LLM.instance_variable_set(:@embedding_model, 'text-embedding-3-small')
     Legion::LLM.instance_variable_set(:@started, true)
   end
 
@@ -296,25 +296,27 @@ RSpec.describe Legion::LLM::Embeddings do
     end
 
     it 'does not resolve provider from chat default_provider when not specified' do
-      allow(Legion::Settings).to receive(:dig).with(:llm, :default_provider).and_return(:bedrock)
-      allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(nil)
+      Legion::Settings[:llm][:default_provider] = :bedrock
+      Legion::LLM.instance_variable_set(:@embedding_provider, nil)
+      Legion::LLM.instance_variable_set(:@embedding_model, nil)
 
-      mock_response = double(vectors: [Array.new(1024, 0.1)], input_tokens: 1)
-      allow(RubyLLM).to receive(:embed).and_return(mock_response)
+      expect(RubyLLM).not_to receive(:embed)
 
       result = described_class.generate(text: 'test')
       expect(result[:provider]).to be_nil
+      expect(result[:error]).to eq('No embedding provider configured')
     end
 
     it 'does not route embeddings to vllm when vllm is the chat default provider' do
-      allow(Legion::Settings).to receive(:dig).with(:llm, :default_provider).and_return(:vllm)
-      allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(nil)
+      Legion::Settings[:llm][:default_provider] = :vllm
+      Legion::LLM.instance_variable_set(:@embedding_provider, nil)
+      Legion::LLM.instance_variable_set(:@embedding_model, nil)
 
-      mock_response = double(vectors: [Array.new(1024, 0.1)], input_tokens: 1)
-      expect(RubyLLM).to receive(:embed).with('test', hash_excluding(provider: :vllm)).and_return(mock_response)
+      expect(RubyLLM).not_to receive(:embed)
 
       result = described_class.generate(text: 'test')
       expect(result[:provider]).to be_nil
+      expect(result[:error]).to eq('No embedding provider configured')
     end
   end
 
@@ -343,11 +345,9 @@ RSpec.describe Legion::LLM::Embeddings do
     end
 
     it 'uses provider_models from embedding settings for bedrock' do
-      allow(Legion::Settings).to receive(:dig).with(:llm, :embedding).and_return(
-        { provider_models: { bedrock: 'amazon.titan-embed-text-v2:0' } }
-      )
+      Legion::Settings[:llm][:embedding][:provider_models] = { bedrock: 'amazon.titan-embed-text-v2:0' }
       Legion::LLM.instance_variable_set(:@embedding_provider, :bedrock)
-      Legion::LLM.instance_variable_set(:@embedding_model, 'amazon.titan-embed-text-v2:0')
+      Legion::LLM.instance_variable_set(:@embedding_model, nil)
       expect(described_class.default_model).to eq('amazon.titan-embed-text-v2:0')
     end
   end


### PR DESCRIPTION
## Summary
- Stops embedding calls from inheriting the chat default provider.
- Adds coverage to ensure vLLM is not used for embeddings unless explicitly configured.
- Bumps version and changelog for the fix.

## Validation
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A
