### PR TITLE
Consume GAIA advisory in LLM executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.8.50] - 2026-05-07
+
+### Fixed
+- Consume GAIA advisory `tool_hint`, `suppress`, and `context_window` data when building native tool definitions and sizing RAG retrieval, so GAIA advisory outputs affect provider calls instead of only appearing in enrichment summaries.
+
 ## [0.8.49] - 2026-04-29
 
 ### Changed

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -603,6 +603,7 @@ module Legion
                        else
                          Types::ToolDefinition.from_tool_class(tool)
                        end
+          return if gaia_tool_suppressed?(definition.name)
           return if definitions.any? { |existing| existing.name == definition.name }
 
           @injected_tool_map[definition.name] = definition.source[:tool_class] if definition.source[:tool_class]
@@ -629,8 +630,13 @@ module Legion
           inject_limit = registry_tool_limit
 
           always_entries = Legion::Settings::Extensions.filter_tools(deferred: false)
+          gaia_entries = gaia_advisory_tool_entries
           triggered_entries = @triggered_tools.any? ? Array(@triggered_tools) : []
-          prioritized = local_provider? ? triggered_entries + always_entries : always_entries + triggered_entries
+          prioritized = if local_provider?
+                          gaia_entries + triggered_entries + always_entries
+                        else
+                          always_entries + gaia_entries + triggered_entries
+                        end
 
           prioritized.each do |entry|
             break if inject_limit && injected_names.size >= inject_limit
@@ -640,6 +646,7 @@ module Legion
                          else
                            Types::ToolDefinition.from_tool_class(entry)
                          end
+            next if gaia_tool_suppressed?(definition.name)
             next if injected_names.include?(definition.name)
 
             tool_class = entry.is_a?(Hash) ? entry[:tool_class] : entry
@@ -660,6 +667,7 @@ module Legion
           deferred_entries.each do |entry|
             definition = Types::ToolDefinition.from_registry_entry(entry)
             next unless requested.include?(definition.name)
+            next if gaia_tool_suppressed?(definition.name)
             next if injected_names.include?(definition.name)
 
             @injected_tool_map[definition.name] = entry[:tool_class] if entry[:tool_class]
@@ -667,6 +675,69 @@ module Legion
             definitions << definition
             injected_names << definition.name
           end
+        end
+
+        def gaia_advisory_tool_entries
+          hint_names = gaia_tool_hint_names
+          return [] if hint_names.empty?
+          return [] unless Legion::Settings::Extensions.respond_to?(:filter_tools)
+
+          entries = Legion::Settings::Extensions.filter_tools(deferred: false) +
+                    Legion::Settings::Extensions.filter_tools(deferred: true)
+          entries.each_with_object([]) do |entry, selected|
+            name = normalized_tool_name(registry_entry_name(entry))
+            next unless hint_names.include?(name)
+            next if gaia_tool_suppressed?(name)
+            next if selected.any? { |existing| normalized_tool_name(registry_entry_name(existing)) == name }
+
+            selected << entry
+          end
+        end
+
+        def gaia_tool_hint_names
+          Array(gaia_advisory_value(:tool_hint)).filter_map do |name|
+            normalized = normalized_tool_name(name)
+            normalized unless normalized.empty?
+          end
+        end
+
+        def gaia_suppressed_tool_names
+          @gaia_suppressed_tool_names ||= Array(gaia_advisory_value(:suppress)).filter_map do |name|
+            normalized = normalized_tool_name(name)
+            normalized unless normalized.empty?
+          end
+        end
+
+        def gaia_tool_suppressed?(name)
+          gaia_suppressed_tool_names.include?(normalized_tool_name(name))
+        end
+
+        def gaia_advisory_value(key)
+          data = gaia_advisory_data
+          return nil unless data.respond_to?(:key?)
+
+          data[key] || data[key.to_s]
+        end
+
+        def gaia_advisory_data
+          enrichment = @enrichments['gaia:advisory']
+          return {} unless enrichment.respond_to?(:key?)
+
+          enrichment[:data] || enrichment['data'] || {}
+        end
+
+        def registry_entry_name(entry)
+          if entry.is_a?(Hash)
+            entry[:name] || entry['name']
+          elsif entry.respond_to?(:tool_name)
+            entry.tool_name
+          elsif entry.respond_to?(:name)
+            entry.name
+          end
+        end
+
+        def normalized_tool_name(name)
+          name.to_s.tr('.', '_')
         end
 
         def native_assistant_tool_message(result, tool_calls)

--- a/lib/legion/llm/inference/steps/rag_context.rb
+++ b/lib/legion/llm/inference/steps/rag_context.rb
@@ -133,7 +133,8 @@ module Legion
             full_limit    = rag_setting(:full_limit, 10)
             compact_limit = rag_setting(:compact_limit, 5)
             confidence    = rag_setting(:min_confidence, 0.5)
-            limit = strategy == :rag_compact ? compact_limit : full_limit
+            limit = apply_gaia_context_limit(strategy == :rag_compact ? compact_limit : full_limit,
+                                             strategy: strategy)
 
             if defined?(::Legion::Extensions::Apollo::Runners::Knowledge)
               ::Legion::Extensions::Apollo::Runners::Knowledge.retrieve_relevant(
@@ -158,6 +159,46 @@ module Legion
           def extract_query
             @request.messages.select { |m| Legion::LLM::Settings.config_value(m, :role).to_s == 'user' }
                              .then { |messages| Legion::LLM::Settings.config_value(messages.last, :content) }
+          end
+
+          def apply_gaia_context_limit(limit, strategy:)
+            gaia_limit = gaia_context_limit(strategy: strategy)
+            return limit unless gaia_limit&.positive?
+
+            [limit, gaia_limit].min
+          end
+
+          def gaia_context_limit(strategy:)
+            window = gaia_advisory_value(:context_window)
+            case window
+            when Hash
+              value = window[strategy] || window[strategy.to_s] ||
+                      window[:limit] || window['limit'] ||
+                      window[:max_entries] || window['max_entries'] ||
+                      window[:context_limit] || window['context_limit']
+              positive_integer(value)
+            when Array
+              window.size.positive? ? window.size : nil
+            else
+              positive_integer(window)
+            end
+          end
+
+          def gaia_advisory_value(key)
+            enrichment = @enrichments['gaia:advisory']
+            return nil unless enrichment.respond_to?(:key?)
+
+            data = enrichment[:data] || enrichment['data'] || {}
+            return nil unless data.respond_to?(:key?)
+
+            data[key] || data[key.to_s]
+          end
+
+          def positive_integer(value)
+            integer = Integer(value)
+            integer.positive? ? integer : nil
+          rescue ArgumentError, TypeError
+            nil
           end
         end
       end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.8.49'
+    VERSION = '0.8.50'
   end
 end

--- a/spec/legion/llm/inference/executor_spec.rb
+++ b/spec/legion/llm/inference/executor_spec.rb
@@ -235,6 +235,53 @@ confidence: 0.9 }],
         expect(names).not_to include('legion_test_skipped')
       end
 
+      it 'uses GAIA tool hints and suppressions when building native tools' do
+        always_entries = [
+          { name: 'legion_query_knowledge', description: 'Suppressed always-loaded tool',
+            input_schema: { type: 'object', properties: {} }, deferred: false }
+        ]
+        deferred_entries = [
+          { name: 'legion_test_extra', description: 'GAIA hinted deferred tool',
+            input_schema: { type: 'object', properties: {} }, deferred: true }
+        ]
+        all_entries = always_entries + deferred_entries
+        extensions_mod = Module.new do
+          define_singleton_method(:tools) { all_entries }
+          define_singleton_method(:filter_tools) do |**criteria|
+            if criteria[:deferred] == false
+              always_entries
+            elsif criteria[:deferred] == true
+              deferred_entries
+            else
+              all_entries
+            end
+          end
+        end
+        stub_const('Legion::Settings::Extensions', extensions_mod)
+
+        req = Legion::LLM::Inference::Request.build(messages: [{ role: :user, content: 'test' }])
+        executor = described_class.new(req)
+        executor.enrichments['gaia:advisory'] = {
+          data: { tool_hint: ['legion.test.extra'], suppress: ['legion_query_knowledge'] }
+        }
+
+        names = executor.send(:native_tool_definitions).map(&:name)
+        expect(names).to include('legion_test_extra')
+        expect(names).not_to include('legion_query_knowledge')
+      end
+
+      it 'suppresses explicitly provided native tools when GAIA says to suppress them' do
+        req = Legion::LLM::Inference::Request.build(
+          messages: [{ role: :user, content: 'test' }],
+          tools:    [{ name: 'blocked_tool', description: 'blocked', parameters: { type: 'object' } }]
+        )
+        executor = described_class.new(req)
+        executor.enrichments['gaia:advisory'] = { data: { suppress: ['blocked_tool'] } }
+
+        names = executor.send(:native_tool_definitions).map(&:name)
+        expect(names).not_to include('blocked_tool')
+      end
+
       it 'caps registry tools for local providers and prioritizes trigger-matched tools' do
         always_entries = 3.times.map do |idx|
           { name: "legion_always_#{idx}", description: 'Always loaded tool',
@@ -261,6 +308,41 @@ confidence: 0.9 }],
         names = executor.send(:native_tool_definitions).map(&:name)
 
         expect(names).to eq(%w[legion_triggered_0 legion_triggered_1])
+      end
+
+      it 'prioritizes GAIA hinted tools before triggered tools for local providers' do
+        always_entries = []
+        hinted_entries = [
+          { name: 'legion_hinted', description: 'Hinted tool',
+            input_schema: { type: 'object', properties: {} }, deferred: true }
+        ]
+        triggered_entries = [
+          { name: 'legion_triggered', description: 'Triggered tool',
+            input_schema: { type: 'object', properties: {} }, deferred: false }
+        ]
+        extensions_mod = Module.new do
+          define_singleton_method(:tools) { hinted_entries + triggered_entries }
+          define_singleton_method(:filter_tools) do |**criteria|
+            if criteria[:deferred] == false
+              always_entries
+            elsif criteria[:deferred] == true
+              hinted_entries
+            else
+              hinted_entries + triggered_entries
+            end
+          end
+        end
+        stub_const('Legion::Settings::Extensions', extensions_mod)
+        Legion::LLM.settings[:tool_trigger][:local_tool_limit] = 1
+
+        req = Legion::LLM::Inference::Request.build(messages: [{ role: :user, content: 'test' }])
+        executor = described_class.new(req)
+        executor.instance_variable_set(:@resolved_provider, :vllm)
+        executor.instance_variable_set(:@triggered_tools, triggered_entries)
+        executor.enrichments['gaia:advisory'] = { data: { tool_hint: ['legion_hinted'] } }
+
+        names = executor.send(:native_tool_definitions).map(&:name)
+        expect(names).to eq(['legion_hinted'])
       end
     end
   end

--- a/spec/legion/llm/inference/steps/rag_context_spec.rb
+++ b/spec/legion/llm/inference/steps/rag_context_spec.rb
@@ -258,6 +258,23 @@ RSpec.describe Legion::LLM::Inference::Steps::RagContext do
       step.step_rag_context
     end
 
+    it 'caps retrieval limit with GAIA advisory context window' do
+      request = Legion::LLM::Inference::Request.build(
+        messages:         [{ role: :user, content: 'what is pgvector?' }],
+        context_strategy: :rag
+      )
+
+      apollo_runner = double('Knowledge')
+      allow(apollo_runner).to receive(:retrieve_relevant)
+        .with(query: 'what is pgvector?', limit: 2, min_confidence: 0.5)
+        .and_return({ success: true, entries: [], count: 0 })
+      stub_const('Legion::Extensions::Apollo::Runners::Knowledge', apollo_runner)
+
+      step = klass.new(request)
+      step.enrichments['gaia:advisory'] = { data: { context_window: { limit: 2 } } }
+      step.step_rag_context
+    end
+
     it 'uses compact_limit for rag_compact strategy' do
       Legion::Settings[:llm][:rag][:compact_limit] = 3
 


### PR DESCRIPTION
## Summary
- Consume GAIA `tool_hint` and `suppress` advisory data while building native tool definitions.
- Cap RAG retrieval limits with GAIA `context_window` advisory data.
- Bump `legion-llm` to `0.8.50` with a changelog entry.

## Verification
- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- `bundle exec rubocop -A`

## Related
- Companion GAIA PR: LegionIO/legion-gaia#29