### PR TITLE
fix instance tier not flowing from discovery into RuleGenerator auto-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Legion LLM Changelog
 
-## [0.10.0] - 2026-05-07
+## [0.9.10] - 2026-05-07
 
 ### Fixed
 - `normalize_model_for_rules` now passes the `tier` field from each discovered model entry through to `RuleGenerator`, so per-instance tier configuration is no longer silently dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion LLM Changelog
 
+## [0.10.0] - 2026-05-07
+
+### Fixed
+- `normalize_model_for_rules` now passes the `tier` field from each discovered model entry through to `RuleGenerator`, so per-instance tier configuration is no longer silently dropped.
+- `RuleGenerator#generate` now prefers a per-model `tier` value from discovery data over the hardcoded `TIER_MAP` provider default, allowing directly-reachable vLLM (and other HTTP-based) instances to route via `:direct` instead of always being assigned `:fleet`.
+
 ## [0.9.9] - 2026-05-07
 
 ### Fixed

--- a/lib/legion/llm/discovery.rb
+++ b/lib/legion/llm/discovery.rb
@@ -212,6 +212,7 @@ module Legion
         # Normalize a discovered model entry into a hash compatible with RuleGenerator
         def normalize_model_for_rules(model_entry)
           h = { 'name' => model_entry[:model] }
+          h['tier'] = model_entry[:tier] if model_entry[:tier]
           h['capabilities'] = model_entry[:capabilities] if model_entry[:capabilities]&.any?
           h['context_length'] = model_entry[:context_length] if model_entry[:context_length]
           h['parameter_count'] = model_entry[:parameter_count] if model_entry[:parameter_count]

--- a/lib/legion/llm/discovery/rule_generator.rb
+++ b/lib/legion/llm/discovery/rule_generator.rb
@@ -46,10 +46,13 @@ module Legion
                 model_name = (model_data[:name] || model_data['name']).to_s
                 next if model_name.empty?
 
+                model_tier = extract_field(model_data, :tier)&.to_sym ||
+                             extract_field(model_data, 'tier')&.to_sym ||
+                             tier
                 capability = embedding_model?(model_data) ? :embed : :chat
-                priority = (TIER_WEIGHT[tier] || 80) - order
-                rules << build_rule(provider, instance_id, model_data, capability, tier, priority)
-                rules << build_rule(provider, instance_id, model_data, :stream, tier, priority) if capability == :chat
+                priority = (TIER_WEIGHT[model_tier] || 80) - order
+                rules << build_rule(provider, instance_id, model_data, capability, model_tier, priority)
+                rules << build_rule(provider, instance_id, model_data, :stream, model_tier, priority) if capability == :chat
                 order += 1
               end
             end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.9'
+    VERSION = '0.10.0'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.10.0'
+    VERSION = '0.9.10'
   end
 end

--- a/spec/legion/llm/discovery/rule_generator_spec.rb
+++ b/spec/legion/llm/discovery/rule_generator_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'legion/llm/discovery/rule_generator'
+require 'legion/llm/discovery'
 require 'legion/llm/router'
 
 RSpec.describe Legion::LLM::Discovery::RuleGenerator do
@@ -332,6 +333,108 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
         tier: :local, provider: :ollama, model: 'llama3'
       )
       expect(resolution.to_h).not_to have_key(:instance)
+    end
+  end
+
+  describe 'per-model tier override in .generate' do
+    it 'uses model-level tier (symbol key) over TIER_MAP when present' do
+      direct_vllm = {
+        vllm: {
+          gpu1: {
+            models: [
+              { 'name' => 'llama3:8b', 'tier' => :direct }
+            ]
+          }
+        }
+      }
+      rules = described_class.generate(direct_vllm)
+      chat_rule = rules.find { |r| r[:name].include?('llama3:8b') && r[:when][:capability] == :chat }
+      expect(chat_rule[:then][:tier]).to eq(:direct)
+    end
+
+    it 'uses model-level tier (string key) over TIER_MAP when present' do
+      direct_vllm = {
+        vllm: {
+          gpu1: {
+            models: [
+              { 'name' => 'mistral:7b', 'tier' => 'direct' }
+            ]
+          }
+        }
+      }
+      rules = described_class.generate(direct_vllm)
+      chat_rule = rules.find { |r| r[:name].include?('mistral:7b') && r[:when][:capability] == :chat }
+      expect(chat_rule[:then][:tier]).to eq(:direct)
+    end
+
+    it 'falls back to TIER_MAP when no per-model tier is present' do
+      default_vllm = {
+        vllm: {
+          gpu1: {
+            models: [
+              { 'name' => 'llama3:8b' }
+            ]
+          }
+        }
+      }
+      rules = described_class.generate(default_vllm)
+      chat_rule = rules.find { |r| r[:name].include?('llama3:8b') && r[:when][:capability] == :chat }
+      expect(chat_rule[:then][:tier]).to eq(:fleet)
+    end
+
+    it 'applies per-model tier override to stream rules as well' do
+      direct_vllm = {
+        vllm: {
+          gpu1: {
+            models: [
+              { 'name' => 'llama3:8b', 'tier' => :direct }
+            ]
+          }
+        }
+      }
+      rules = described_class.generate(direct_vllm)
+      stream_rule = rules.find { |r| r[:name].include?('llama3:8b') && r[:when][:capability] == :stream }
+      expect(stream_rule[:then][:tier]).to eq(:direct)
+    end
+  end
+end
+
+RSpec.describe Legion::LLM::Discovery do
+  before do
+    Legion::LLM::Discovery.reset!
+  end
+
+  describe '.normalize_model_for_rules (via discovered_instances)' do
+    context 'when model entry has a tier' do
+      it 'includes tier in the normalized hash' do
+        model_entry = {
+          model:    'llama3:8b',
+          provider: :vllm,
+          instance: :gpu1,
+          tier:     :direct
+        }
+        result = Legion::LLM::Discovery.send(:normalize_model_for_rules, model_entry)
+        expect(result['tier']).to eq(:direct)
+      end
+    end
+
+    context 'when model entry has no tier' do
+      it 'omits the tier key entirely' do
+        model_entry = {
+          model:    'llama3:8b',
+          provider: :vllm,
+          instance: :gpu1,
+          tier:     nil
+        }
+        result = Legion::LLM::Discovery.send(:normalize_model_for_rules, model_entry)
+        expect(result).not_to have_key('tier')
+      end
+    end
+
+    it 'always includes the model name' do
+      model_entry = { model: 'llama3:8b', provider: :vllm, instance: :gpu1 }
+      result = Legion::LLM::Discovery.send(:normalize_model_for_rules, model_entry)
+      expect(result['name']).to eq('llama3:8b')
     end
   end
 end


### PR DESCRIPTION
## Summary
- `Discovery#normalize_model_for_rules` now includes `'tier'` in the hash it passes to `RuleGenerator` when the model entry has a tier set
- `RuleGenerator#generate` now extracts the per-model tier (via `extract_field`) and prefers it over the `TIER_MAP` default for both `chat` and `stream` rules; `TIER_MAP` remains the fallback when no per-model tier is present
- Added specs covering both the `normalize_model_for_rules` tier inclusion/omission and the `RuleGenerator` per-model override and TIER_MAP fallback behaviour

## Test plan
- [ ] `bundle exec rspec` passes (full suite, zero failures)
- [ ] `bundle exec rubocop` passes (zero offenses)
- [ ] New specs: `normalize_model_for_rules` includes `'tier'` when present, omits it when nil
- [ ] New specs: `RuleGenerator.generate` uses per-model `:direct` tier (symbol + string key) over `TIER_MAP :fleet`
- [ ] New specs: `RuleGenerator.generate` falls back to `TIER_MAP` when no per-model tier
- [ ] New specs: stream rules also pick up the per-model tier override

Closes #111