### PR TITLE
Fix method shadowing: rename Metering#settings_value to extract_hash_value (v0.9.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.9.16] - 2026-05-11
+
+### Fixed
+- Renamed `Metering#settings_value` to `extract_hash_value` to fix method shadowing with `Legion::Logging::Helper#settings_value`, which resolves a `wrong number of arguments (given 3, expected 2)` error raised from `instance_log_level` when metering is active.
+
 ## [0.9.15] - 2026-05-08
 
 ### Fixed

--- a/lib/legion/llm/metering.rb
+++ b/lib/legion/llm/metering.rb
@@ -142,26 +142,26 @@ module Legion
       def extract_usage(response)
         return { input_tokens: 0, output_tokens: 0 } unless response.is_a?(Hash)
 
-        usage = settings_value(response, :usage) || {}
+        usage = extract_hash_value(response, :usage) || {}
         {
-          input_tokens:  settings_value(usage, :input_tokens) || settings_value(usage, :prompt_tokens) || 0,
-          output_tokens: settings_value(usage, :output_tokens) || settings_value(usage, :completion_tokens) || 0
+          input_tokens:  extract_hash_value(usage, :input_tokens) || extract_hash_value(usage, :prompt_tokens) || 0,
+          output_tokens: extract_hash_value(usage, :output_tokens) || extract_hash_value(usage, :completion_tokens) || 0
         }
       end
 
       def extract_provider(response)
         return nil unless response.is_a?(Hash)
 
-        settings_value(settings_value(response, :meta), :provider) || settings_value(response, :provider)
+        extract_hash_value(extract_hash_value(response, :meta), :provider) || extract_hash_value(response, :provider)
       end
 
       def extract_model(response)
         return nil unless response.is_a?(Hash)
 
-        settings_value(settings_value(response, :meta), :model) || settings_value(response, :model)
+        extract_hash_value(extract_hash_value(response, :meta), :model) || extract_hash_value(response, :model)
       end
 
-      def settings_value(hash, key)
+      def extract_hash_value(hash, key)
         return nil unless hash.respond_to?(:key?)
 
         string_key = key.to_s

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.15'
+    VERSION = '0.9.16'
   end
 end


### PR DESCRIPTION
## Summary

- `Legion::LLM::Metering` extended `Legion::Logging::Helper` but also defined its own `module_function settings_value(hash, key)` (2 args), which shadowed `Helper#settings_value(source, *keys)` (variadic).
- Any `Helper` codepath calling `settings_value` with 3 args — e.g. `settings_value(source, :logger, :level)` inside `instance_log_level` — raised `ArgumentError: wrong number of arguments (given 3, expected 2)`.
- Renamed the `Metering`-local helper to `extract_hash_value` and updated all 8 internal call sites. No behavior change — only the name differs.

## Test plan

- [x] `bundle exec rspec` — 2338 examples, 0 failures
- [x] `bundle exec rubocop -A` — 343 files inspected, no offenses
- [x] Version bumped to `0.9.16`
- [x] CHANGELOG updated with entry for `0.9.16`