### PR TITLE
fix: tool_calls normalization, system message guard, add /api/llm/tiers + tier routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Legion LLM Changelog
 
+## [0.9.19] - 2026-05-11
+
+### Added
+- `GET /api/llm/tiers` — full RESTful tier hierarchy endpoint with sub-routes: `/:tier`, `/:tier/providers`, `/:tier/providers/:provider`, `/:tier/providers/:provider/instances`, `/:tier/providers/:provider/instances/:instance`, `/:tier/providers/:provider/instances/:instance/models`, `/:tier/providers/:provider/models`. Returns tier availability, provider health, instance details, and model listings in a structured tree.
+- `POST /api/llm/inference` now accepts `tier` parameter in request body, passed through to the routing pipeline via `Request.extra[:tier]`. Supports values: `local`, `fleet`, `openai_compat`, `cloud`, `frontier`.
+- Request log for `/api/llm/inference` now includes `requested_tier` field.
+
+### Changed
+- `GET /api/llm/offerings` response restructured from flat array to grouped hash: `tier → provider → instance → [offerings]`. Individual offering lookup (`GET /api/llm/offerings/:id`) unchanged.
+
 ## [0.9.18] - 2026-05-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion LLM Changelog
 
+## [0.9.18] - 2026-05-11
+
+### Fixed
+- `NativeResponseAdapter` now coerces tool_calls from the Hash-keyed-by-name format (returned by OpenAI-compatible providers via lex-llm) into a flat Array of Hashes, preventing TypeError crashes in `step_tool_calls`, `response_tool_calls`, and the native tool loop when streaming tool-use responses from vllm/ollama.
+- `LexLLMAdapter#normalize_messages` merges enriched system content with an existing system message at index 0 instead of prepending a duplicate, preventing vllm "System message must be at the beginning" rejections during gaia narrator ticks.
+
 ## [0.9.17] - 2026-05-11
 
 ### Fixed

--- a/lib/legion/llm/api.rb
+++ b/lib/legion/llm/api.rb
@@ -9,6 +9,7 @@ require_relative 'api/native/models'
 require_relative 'api/native/offerings'
 require_relative 'api/native/instances'
 require_relative 'api/native/routing'
+require_relative 'api/native/tiers'
 require_relative 'api/translators/openai_request'
 require_relative 'api/translators/openai_response'
 require_relative 'api/openai/chat_completions'
@@ -36,6 +37,7 @@ module Legion
         Native::Offerings.registered(app)
         Native::Instances.registered(app)
         Native::Routing.registered(app)
+        Native::Tiers.registered(app)
         OpenAI::ChatCompletions.registered(app)
         OpenAI::Models.registered(app)
         OpenAI::Embeddings.registered(app)

--- a/lib/legion/llm/api/native/inference.rb
+++ b/lib/legion/llm/api/native/inference.rb
@@ -23,6 +23,7 @@ module Legion
               requested_tools = body[:requested_tools] || []
               model           = body[:model]
               provider        = body[:provider]
+              tier            = body[:tier]
               caller_context  = body[:caller]
               conversation_id = body[:conversation_id]
               request_id      = body[:request_id] || SecureRandom.uuid
@@ -88,11 +89,15 @@ module Legion
                 "[llm][api][inference] action=accepted request_id=#{request_id} " \
                 "conversation_id=#{conversation_id || 'none'} caller=#{caller_summary} " \
                 "messages=#{messages.size} client_tools=#{tools.size} requested_tools=#{Array(requested_tools).size} " \
-                "requested_provider=#{provider || 'auto'} requested_model=#{model || 'auto'} stream=#{streaming}"
+                "requested_tier=#{tier || 'auto'} requested_provider=#{provider || 'auto'} " \
+                "requested_model=#{model || 'auto'} stream=#{streaming}"
               )
 
               require 'legion/llm/inference/request' unless defined?(Legion::LLM::Inference::Request)
               require 'legion/llm/inference/executor' unless defined?(Legion::LLM::Inference::Executor)
+
+              extra = {}
+              extra[:tier] = tier.to_sym if tier
 
               pipeline_request = Legion::LLM::Inference::Request.build(
                 id:              request_id,
@@ -104,7 +109,8 @@ module Legion
                 conversation_id: conversation_id,
                 metadata:        { requested_tools: requested_tools },
                 stream:          streaming,
-                cache:           { strategy: :default, cacheable: true }
+                cache:           { strategy: :default, cacheable: true },
+                extra:           extra
               )
 
               setup_ms = ((::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - route_t0) * 1000).round

--- a/lib/legion/llm/api/native/offerings.rb
+++ b/lib/legion/llm/api/native/offerings.rb
@@ -17,11 +17,12 @@ module Legion
               require_llm!
 
               filters = Legion::LLM::API::Native::Offerings.request_filters(params)
-              offerings = Legion::LLM::Inventory.offerings(filters)
+              raw_offerings = Legion::LLM::Inventory.offerings(filters)
+              grouped = Legion::LLM::API::Native::Offerings.group_offerings(raw_offerings)
 
               json_response({
-                              offerings: offerings,
-                              summary:   Legion::LLM::API::Native::Offerings.summary(offerings, filters)
+                              offerings: grouped,
+                              summary:   Legion::LLM::API::Native::Offerings.summary(raw_offerings)
                             })
             rescue StandardError => e
               handle_exception(e, level: :error, handled: true, operation: 'llm.api.offerings.list')
@@ -59,14 +60,45 @@ module Legion
             }
           end
 
-          def self.summary(offerings, filters)
+          def self.group_offerings(offerings)
+            grouped = {}
+
+            offerings.each do |offering|
+              tier = (offering[:tier] || :unknown).to_s
+              provider = (offering[:provider_family] || :unknown).to_s
+              instance = (offering[:instance_id] || offering[:provider_instance] || :default).to_s
+
+              grouped[tier] ||= {}
+              grouped[tier][provider] ||= {}
+              grouped[tier][provider][instance] ||= []
+              grouped[tier][provider][instance] << compact_offering(offering)
+            end
+
+            grouped
+          end
+
+          def self.compact_offering(offering)
+            {
+              id:           offering[:offering_id] || offering[:id],
+              model:        offering[:model].to_s,
+              type:         offering[:type].to_s,
+              model_family: offering[:model_family]&.to_s,
+              capabilities: Array(offering[:capabilities]).map(&:to_s),
+              limits:       offering[:limits] || {},
+              enabled:      offering[:enabled] != false,
+              cost:         offering[:cost] || {},
+              health:       offering[:health] || {}
+            }.compact
+          end
+
+          def self.summary(offerings)
             {
               total:     offerings.size,
-              operation: filters[:type]&.to_s,
-              models:    offerings.map { |offering| offering[:model] }.uniq.size,
-              providers: offerings.map { |offering| offering[:provider_family] }.uniq.size,
-              instances: offerings.map { |offering| offering[:instance_id] }.uniq.size
-            }.compact
+              tiers:     offerings.map { |o| (o[:tier] || :unknown).to_s }.uniq.size,
+              providers: offerings.map { |o| (o[:provider_family] || :unknown).to_s }.uniq.size,
+              instances: offerings.map { |o| (o[:instance_id] || :default).to_s }.uniq.size,
+              models:    offerings.map { |o| o[:model] }.uniq.size
+            }
           end
         end
       end

--- a/lib/legion/llm/api/native/tiers.rb
+++ b/lib/legion/llm/api/native/tiers.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require 'legion/logging/helper'
+
+module Legion
+  module LLM
+    module API
+      module Native
+        module Tiers
+          extend Legion::Logging::Helper
+
+          def self.registered(app) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+            log.debug('[llm][api][tiers] registering tier routes')
+
+            app.get '/api/llm/tiers' do
+              require_llm!
+
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              json_response({
+                              tiers:        tiers_data,
+                              priority:     Legion::LLM::API::Native::Tiers.tier_priority,
+                              privacy_mode: Legion::LLM::API::Native::Tiers.privacy_mode?
+                            })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.list')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            app.get '/api/llm/tiers/:tier' do
+              require_llm!
+
+              tier_name = params[:tier].to_s
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              tier = tiers_data[tier_name]
+              halt json_error('tier_not_found', "Tier '#{tier_name}' not found", status_code: 404) unless tier
+
+              json_response({ tier: tier_name, **tier })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.get')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            app.get '/api/llm/tiers/:tier/providers' do
+              require_llm!
+
+              tier_name = params[:tier].to_s
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              tier = tiers_data[tier_name]
+              halt json_error('tier_not_found', "Tier '#{tier_name}' not found", status_code: 404) unless tier
+
+              json_response({ tier: tier_name, providers: tier[:providers] })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.providers')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            app.get '/api/llm/tiers/:tier/providers/:provider' do
+              require_llm!
+
+              tier_name = params[:tier].to_s
+              provider_name = params[:provider].to_s
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              tier = tiers_data[tier_name]
+              halt json_error('tier_not_found', "Tier '#{tier_name}' not found", status_code: 404) unless tier
+
+              provider = tier.dig(:providers, provider_name)
+              halt json_error('provider_not_found', "Provider '#{provider_name}' not found in tier '#{tier_name}'", status_code: 404) unless provider
+
+              json_response({ tier: tier_name, provider: provider_name, **provider })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.provider')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            app.get '/api/llm/tiers/:tier/providers/:provider/instances' do
+              require_llm!
+
+              tier_name = params[:tier].to_s
+              provider_name = params[:provider].to_s
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              tier = tiers_data[tier_name]
+              halt json_error('tier_not_found', "Tier '#{tier_name}' not found", status_code: 404) unless tier
+
+              provider = tier.dig(:providers, provider_name)
+              halt json_error('provider_not_found', "Provider '#{provider_name}' not found in tier '#{tier_name}'", status_code: 404) unless provider
+
+              json_response({ tier: tier_name, provider: provider_name, instances: provider[:instances] })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.instances')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            app.get '/api/llm/tiers/:tier/providers/:provider/instances/:instance' do
+              require_llm!
+
+              tier_name = params[:tier].to_s
+              provider_name = params[:provider].to_s
+              instance_name = params[:instance].to_s
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              tier = tiers_data[tier_name]
+              halt json_error('tier_not_found', "Tier '#{tier_name}' not found", status_code: 404) unless tier
+
+              provider = tier.dig(:providers, provider_name)
+              halt json_error('provider_not_found', "Provider '#{provider_name}' not found in tier '#{tier_name}'", status_code: 404) unless provider
+
+              instance = provider.dig(:instances, instance_name)
+              halt json_error('instance_not_found', "Instance '#{instance_name}' not found", status_code: 404) unless instance
+
+              json_response({ tier: tier_name, provider: provider_name, instance: instance_name, **instance })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.instance')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            app.get '/api/llm/tiers/:tier/providers/:provider/instances/:instance/models' do
+              require_llm!
+
+              tier_name = params[:tier].to_s
+              provider_name = params[:provider].to_s
+              instance_name = params[:instance].to_s
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              tier = tiers_data[tier_name]
+              halt json_error('tier_not_found', "Tier '#{tier_name}' not found", status_code: 404) unless tier
+
+              provider = tier.dig(:providers, provider_name)
+              halt json_error('provider_not_found', "Provider '#{provider_name}' not found in tier '#{tier_name}'", status_code: 404) unless provider
+
+              instance = provider.dig(:instances, instance_name)
+              halt json_error('instance_not_found', "Instance '#{instance_name}' not found", status_code: 404) unless instance
+
+              json_response({ tier: tier_name, provider: provider_name, instance: instance_name, models: instance[:models] })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.instance_models')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            app.get '/api/llm/tiers/:tier/providers/:provider/models' do
+              require_llm!
+
+              tier_name = params[:tier].to_s
+              provider_name = params[:provider].to_s
+              tiers_data = Legion::LLM::API::Native::Tiers.build_tiers_tree
+              tier = tiers_data[tier_name]
+              halt json_error('tier_not_found', "Tier '#{tier_name}' not found", status_code: 404) unless tier
+
+              provider = tier.dig(:providers, provider_name)
+              halt json_error('provider_not_found', "Provider '#{provider_name}' not found in tier '#{tier_name}'", status_code: 404) unless provider
+
+              all_models = provider[:instances].values.flat_map { |inst| inst[:models] }
+              seen = {}
+              unique_models = all_models.select { |m| seen[m[:id]] ? false : (seen[m[:id]] = true) }
+
+              json_response({ tier: tier_name, provider: provider_name, models: unique_models })
+            rescue StandardError => e
+              handle_exception(e, level: :error, handled: true, operation: 'llm.api.tiers.provider_models')
+              json_error('tiers_error', e.message, status_code: 500)
+            end
+
+            log.debug('[llm][api][tiers] tier routes registered')
+          end
+
+          def self.tier_priority
+            routing_config = Legion::LLM::Settings.value(:routing) || {}
+            Array(routing_config[:tier_priority] || %w[local fleet openai_compat cloud frontier])
+          end
+
+          def self.privacy_mode?
+            return false unless defined?(Legion::LLM::Router)
+
+            Legion::LLM::Router.respond_to?(:privacy_mode?) && Legion::LLM::Router.privacy_mode?
+          end
+
+          def self.tier_available?(tier_sym)
+            return true unless defined?(Legion::LLM::Router) && Legion::LLM::Router.respond_to?(:tier_available?)
+
+            Legion::LLM::Router.tier_available?(tier_sym)
+          end
+
+          def self.build_tiers_tree
+            offerings = Legion::LLM::Inventory.offerings({})
+            grouped = {}
+
+            offerings.each do |offering|
+              tier_name = (offering[:tier] || :unknown).to_s
+              provider_name = (offering[:provider_family] || :unknown).to_s
+              instance_name = (offering[:instance_id] || offering[:provider_instance] || :default).to_s
+
+              grouped[tier_name] ||= { available: tier_available?(tier_name.to_sym), providers: {} }
+              grouped[tier_name][:providers][provider_name] ||= { instances: {} }
+              grouped[tier_name][:providers][provider_name][:instances][instance_name] ||= {
+                health:       offering_instance_health(provider_name, instance_name),
+                capabilities: [],
+                models:       []
+              }
+
+              inst = grouped[tier_name][:providers][provider_name][:instances][instance_name]
+              inst[:capabilities] = (inst[:capabilities] + Array(offering[:capabilities])).uniq.sort
+              inst[:models] << build_model_entry(offering)
+            end
+
+            # Sort tiers by priority order
+            priority = tier_priority
+            sorted = {}
+            priority.each { |t| sorted[t] = grouped.delete(t) if grouped.key?(t) }
+            grouped.each { |t, v| sorted[t] = v }
+
+            # Ensure all priority tiers appear even if empty
+            priority.each do |t|
+              sorted[t] ||= { available: tier_available?(t.to_sym), providers: {} }
+            end
+
+            sorted
+          end
+
+          def self.build_model_entry(offering)
+            {
+              id:           offering[:model].to_s,
+              offering_id:  offering[:offering_id] || offering[:id],
+              type:         offering[:type].to_s,
+              capabilities: Array(offering[:capabilities]).map(&:to_s),
+              limits:       offering[:limits] || {},
+              enabled:      offering[:enabled] != false,
+              cost:         offering[:cost] || {},
+              model_family: offering[:model_family]&.to_s
+            }.compact
+          end
+
+          def self.offering_instance_health(provider_name, instance_name)
+            return 'unknown' unless defined?(Legion::LLM::Router) && Legion::LLM::Router.respond_to?(:health_tracker)
+
+            tracker = Legion::LLM::Router.health_tracker
+            return 'unknown' unless tracker
+
+            tracker.circuit_state(provider_name.to_sym, instance: instance_name.to_sym).to_s
+          rescue StandardError
+            'unknown'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/llm/call/dispatch.rb
+++ b/lib/legion/llm/call/dispatch.rb
@@ -37,7 +37,7 @@ module Legion
           @content             = extracted[:result].to_s
           @model               = result_hash[:model]
           @metadata            = extracted[:metadata] || {}
-          @tool_calls          = result_hash[:tool_calls] || []
+          @tool_calls          = self.class.coerce_tool_calls(result_hash[:tool_calls])
           @stop_reason         = result_hash[:stop_reason]
           @thinking            = extracted[:thinking]
           usage                = self.class.coerce_usage(result_hash[:usage])
@@ -73,7 +73,7 @@ module Legion
               cache_write_tokens: raw.respond_to?(:cache_creation_tokens) ? raw.cache_creation_tokens.to_i : 0
             ),
             metadata:    raw.respond_to?(:metadata) && raw.metadata.is_a?(Hash) ? raw.metadata : {},
-            tool_calls:  raw.respond_to?(:tool_calls) ? raw.tool_calls : [],
+            tool_calls:  raw.respond_to?(:tool_calls) ? coerce_tool_calls(raw.tool_calls) : [],
             stop_reason: raw.respond_to?(:stop_reason) ? raw.stop_reason : nil,
             thinking:    raw.respond_to?(:thinking) ? raw.thinking : nil
           }.compact
@@ -105,6 +105,29 @@ module Legion
             cache_read_tokens:  (raw_usage[:cache_read_tokens] || raw_usage['cache_read_tokens']).to_i,
             cache_write_tokens: (raw_usage[:cache_write_tokens] || raw_usage['cache_write_tokens']).to_i
           )
+        end
+
+        def self.coerce_tool_calls(raw)
+          return [] if raw.nil?
+          return raw if raw.is_a?(Array)
+
+          return raw.values.filter_map { |entry| coerce_single_tool_call(entry) } if raw.is_a?(Hash) && !single_tool_call_hash?(raw)
+
+          [coerce_single_tool_call(raw)].compact
+        end
+
+        def self.single_tool_call_hash?(hash)
+          hash.key?(:name) || hash.key?('name') || hash.key?(:function) || hash.key?('function')
+        end
+
+        def self.coerce_single_tool_call(entry)
+          if entry.respond_to?(:id) && entry.respond_to?(:name)
+            return { id: entry.id, name: entry.name, arguments: entry.respond_to?(:arguments) ? entry.arguments : {} }
+          end
+
+          return entry if entry.is_a?(Hash)
+
+          nil
         end
 
         def self.merge_thinking_payloads(existing, extracted)

--- a/lib/legion/llm/call/dispatch.rb
+++ b/lib/legion/llm/call/dispatch.rb
@@ -2,11 +2,7 @@
 
 require 'legion/logging/helper'
 
-begin
-  require 'legion/extensions/llm/responses/thinking_extractor'
-rescue LoadError
-  nil
-end
+require 'legion/extensions/llm/responses/thinking_extractor'
 
 module Legion
   module LLM

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -150,7 +150,7 @@ module Legion
         def normalize_messages(messages, system: nil)
           message_class = lex_llm_namespace::Message
           raw_messages = Array(messages)
-          raw_messages = [{ role: :system, content: system }] + raw_messages if present_system?(system)
+          raw_messages = prepend_or_merge_system(raw_messages, system) if present_system?(system)
 
           raw_messages.map do |message|
             next message if message.is_a?(message_class)
@@ -162,6 +162,22 @@ module Legion
               tool_calls:   message_hash[:tool_calls],
               tool_call_id: message_hash[:tool_call_id]
             )
+          end
+        end
+
+        def prepend_or_merge_system(raw_messages, system)
+          first = raw_messages.first
+          first_role = if first.is_a?(Hash)
+                         first[:role] || first['role']
+                       elsif first.respond_to?(:role)
+                         first.role
+                       end
+          if first_role.to_s == 'system'
+            existing_content = first.is_a?(Hash) ? (first[:content] || first['content']) : first.content
+            merged = { role: :system, content: "#{system}\n\n#{existing_content}" }
+            [merged] + raw_messages[1..]
+          else
+            [{ role: :system, content: system }] + raw_messages
           end
         end
 

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.18'
+    VERSION = '0.9.19'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.17'
+    VERSION = '0.9.18'
   end
 end

--- a/spec/legion/llm/routes_offer_instances_spec.rb
+++ b/spec/legion/llm/routes_offer_instances_spec.rb
@@ -58,13 +58,12 @@ if defined?(Sinatra::Base) && defined?(Legion::LLM::Routes)
       body = Legion::JSON.load(response.body)
 
       expect(response.status).to eq(200)
-      expect(body[:data][:summary]).to include(total: 1, operation: 'inference')
-      expect(body[:data][:offerings].first).to include(
-        model:             'qwen3.6-27b',
-        provider_family:   'vllm',
-        provider_instance: 'vllm-gpu-01',
-        instance_id:       'vllm-gpu-01'
-      )
+      expect(body[:data][:summary]).to include(total: 1)
+
+      offerings_tree = body[:data][:offerings]
+      all_offerings = offerings_tree.values.flat_map { |providers| providers.values.flat_map { |instances| instances.values.flatten } }
+      expect(all_offerings.size).to eq(1)
+      expect(all_offerings.first[:model]).to eq('qwen3.6-27b')
     end
 
     it 'returns offering details by offering id' do


### PR DESCRIPTION
## Summary
- **Tool calls normalization**: `NativeResponseAdapter` now coerces tool_calls from the Hash-keyed-by-name format (returned by OpenAI-compatible providers) into a flat Array of Hashes. Prevents TypeError crashes in `step_tool_calls`, `response_tool_calls`, and the native tool loop.
- **System message guard**: `LexLLMAdapter#normalize_messages` merges enriched system content with an existing system message at index 0 instead of prepending a duplicate, preventing vllm "System message must be at the beginning" rejections.
- **`GET /api/llm/tiers`**: Full RESTful tier hierarchy with sub-routes (`/:tier`, `/:tier/providers`, `/:tier/providers/:provider`, `/:tier/providers/:provider/instances`, `/:tier/providers/:provider/instances/:instance`, `/:tier/providers/:provider/instances/:instance/models`, `/:tier/providers/:provider/models`). Returns tier availability, provider health, instance details, and model listings.
- **`POST /api/llm/inference` tier support**: Now accepts `tier` in request body, passed to the routing pipeline via `Request.extra[:tier]`. Supports: `local`, `fleet`, `openai_compat`, `cloud`, `frontier`.
- **`GET /api/llm/offerings` restructured**: Response changed from flat array to grouped hash (`tier → provider → instance → [offerings]`). Query param filtering preserved. Individual offering lookup unchanged.
- **Request logging**: `/api/llm/inference` log line now includes `requested_tier` field.

## Test plan
- [x] 2338 specs pass, 0 failures
- [x] 0 rubocop offenses
- [ ] Verify tool execution works in Kai chat with vllm provider
- [ ] Verify gaia narrator tick no longer produces "System message must be at the beginning" errors
- [ ] Verify `GET /api/llm/tiers` returns correct hierarchy
- [ ] Verify `POST /api/llm/inference` with `tier: "local"` routes to local provider
- [ ] Verify `GET /api/llm/offerings` returns grouped format