### PR TITLE
Fix instance routing: wire instance through full pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 - Prompt dispatch: provider-inferable model-only calls such as `gpt-5.4` infer the provider instead of pairing the model with `llm.default_provider`.
+- Executor: provider-tier lookup failures are logged and return nil instead of silently defaulting to `:cloud`.
+- LexLLMAdapter: optional content-block accessor fallbacks now capture and debug-log probe errors instead of bare-rescuing them.
 
 ## [0.9.27] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Executor: provider-tier lookup failures are logged and return nil instead of silently defaulting to `:cloud`.
 - LexLLMAdapter: optional content-block accessor fallbacks now capture and debug-log probe errors instead of bare-rescuing them.
 - Auto routing: unresolved `legionio` requests now raise a clear provider error instead of falling back to configured defaults.
+- Routing: model-only requests stay on provider inference while explicit provider/instance/tier requests still get registry defaults without requiring rule routing.
 
 ## [0.9.27] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Legion LLM Changelog
 
+## [0.9.28] - 2026-05-15
+
+### Added
+- API: `/api/llm/models` now surfaces a static `LegionIO` model (`id: legionio`) as the default auto-routing placeholder.
+
+### Changed
+- Routing: `model: "legionio"` clears explicit provider/model/instance/tier routing and sends the request through the router chain using the configured default intent.
+- Routing: default tier priority now includes `direct` between `local` and `fleet`, and discovery-generated rule scores honor `routing.tier_priority`.
+
+### Fixed
+- Prompt dispatch: provider-inferable model-only calls such as `gpt-5.4` infer the provider instead of pairing the model with `llm.default_provider`.
+
 ## [0.9.27] - 2026-05-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Legion LLM Changelog
 
+## [0.9.25] - 2026-05-14
+
+### Added
+- Router: `TIER_RANK` constant — ordered quality ranking of tiers (local → direct → fleet → openai_compat → cloud → frontier)
+- Executor: `skip_same_tier!` — on `ContextOverflow`, immediately skips all remaining same-tier candidates and routes to a higher-tier provider with a larger context window
+- Executor: lateral vs. escalation move classification in per-attempt log line (`move=lateral` for same-tier, `move=escalation` for higher-tier)
+
+### Fixed
+- Executor: `build_fallback_resolutions` now sorts lateral alternatives (same-tier) before escalation candidates (higher-tier), ensuring the router tries other instances on the same tier before promoting to a more expensive tier
+- Executor: deduplication in escalation loop is now fully safe — `tried` entry is recorded on both success-break and every rescue path
+- EscalationChain: `padded_resolutions` no longer pads the list by repeating the last resolution — only real distinct options are tried
+
 ## [0.9.24] - 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion LLM Changelog
 
+## [0.9.26] - 2026-05-15
+
+### Fixed
+- Discovery: `detect_embedding_from_registry` no longer sets `@can_embed = true` when no model is resolvable — adds `first_embedding_model_for(provider, instance)` as a third fallback scanning the discovered model catalog; returns `false` (allowing legacy probe to run) when all three sources yield nothing (#121)
+- RagContext: `positive_integer` no longer raises `TypeError` when `value` is nil or an empty string — adds empty-string guard before `Kernel#Integer()` call so GAIA advisory `context_window: nil` does not abort the inference pipeline (#122)
+- LexLLMAdapter: `text_part_content` now handles Anthropic-style `[{type:"text", text:"…"}]` content block arrays — flattens them to plain text instead of calling `.to_s` on the array, preventing Ruby array literals from leaking into provider prompts (#123)
+- Embeddings/Discovery: `embedding_config_value` and `embedding_settings` now accept the deprecated plural `"embeddings"` key alongside the canonical singular `"embedding"` key, emitting a deprecation warning; fixes silent misconfiguration when users follow doc examples that used the plural spelling (#124)
+
 ## [0.9.25] - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.9.27] - 2026-05-15
+
+### Fixed
+- Router/Executor: provider-scoped instance resolution no longer applies a global `llm.default_instance` to models inferred for another provider; invalid explicit instances now fall back to that provider's registered default instance instead of dispatching to an unregistered `provider/instance` pair.
+
 ## [0.9.26] - 2026-05-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Prompt dispatch: provider-inferable model-only calls such as `gpt-5.4` infer the provider instead of pairing the model with `llm.default_provider`.
 - Executor: provider-tier lookup failures are logged and return nil instead of silently defaulting to `:cloud`.
 - LexLLMAdapter: optional content-block accessor fallbacks now capture and debug-log probe errors instead of bare-rescuing them.
+- Auto routing: unresolved `legionio` requests now raise a clear provider error instead of falling back to configured defaults.
 
 ## [0.9.27] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - API: `instance` from POST body was silently dropped — never forwarded into routing hash
 - Executor: Gaia advisory tier assignment no longer overrides explicit `provider`+`instance` from caller
 - Executor: `instance` now passed through `routing_resolution_for` to `Router.resolve`/`resolve_chain`
+- Executor: `build_default_escalation_chain` now passes resolved provider/instance/model — previously ignored them and built a full auto chain, routing to vllm/fleet instead of the requested provider
 - Router: `resolve`/`resolve_chain` accept `instance:` param; short-circuit to `explicit_resolution` when `provider` or `instance` is set (not just `tier`)
 - Router: `explicit_resolution` honors caller-supplied instance instead of always pulling from registry; infers tier from `PROVIDER_TIER` when not explicitly given
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Legion LLM Changelog
 
+## [0.9.24] - 2026-05-14
+
+### Fixed
+- API: `instance` from POST body was silently dropped — never forwarded into routing hash
+- Executor: Gaia advisory tier assignment no longer overrides explicit `provider`+`instance` from caller
+- Executor: `instance` now passed through `routing_resolution_for` to `Router.resolve`/`resolve_chain`
+- Router: `resolve`/`resolve_chain` accept `instance:` param; short-circuit to `explicit_resolution` when `provider` or `instance` is set (not just `tier`)
+- Router: `explicit_resolution` honors caller-supplied instance instead of always pulling from registry; infers tier from `PROVIDER_TIER` when not explicitly given
+
 ## [0.9.23] - 2026-05-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ### Added
 - Router: `TIER_RANK` constant — ordered quality ranking of tiers (local → direct → fleet → openai_compat → cloud → frontier)
+- Router: `explicit_resolution` promoted to public — callable directly from executor without `send`
+- Router: `chain_from_defaults` appends all registered fallback providers after the primary so the chain has real alternatives to escalate to (previously single-entry when a default provider was configured)
+- Executor: `run_escalation_resolution` extracted from escalation loop — encapsulates per-attempt dispatch, error rescue, and `tried[]` tracking
 - Executor: `skip_same_tier!` — on `ContextOverflow`, immediately skips all remaining same-tier candidates and routes to a higher-tier provider with a larger context window
 - Executor: lateral vs. escalation move classification in per-attempt log line (`move=lateral` for same-tier, `move=escalation` for higher-tier)
 
 ### Fixed
-- Executor: `build_fallback_resolutions` now sorts lateral alternatives (same-tier) before escalation candidates (higher-tier), ensuring the router tries other instances on the same tier before promoting to a more expensive tier
-- Executor: deduplication in escalation loop is now fully safe — `tried` entry is recorded on both success-break and every rescue path
+- Router: `explicit_resolution` handles nil `provider` and nil `tier` without raising `NoMethodError`
+- Executor: `build_fallback_resolutions` sorts lateral alternatives (same-tier) before escalation candidates (higher-tier) — tries other instances at the same tier before promoting to a more expensive one
+- Executor: deduplication in escalation loop is fully safe — `tried` entry is recorded on all rescue paths and on quality failure
 - EscalationChain: `padded_resolutions` no longer pads the list by repeating the last resolution — only real distinct options are tried
 
 ## [0.9.24] - 2026-05-14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -745,6 +745,26 @@ These rules are enforced across all legion-llm code. Violations will be caught i
 - **Advanced signals**: Budget tracking, GPU utilization monitoring, per-tenant spend limits
 - **Fleet auto-scaling**: Dynamic worker pool sizing based on queue depth and latency
 
+## Provider Registration & Model Resolution
+
+- `discover_instances` in each lex-llm-* must include `default_model` in returned config — it flows to registry metadata via `instance_metadata` in `call/providers.rb`
+- Router resolves models via: `registry_entry_for_provider(provider)` → `registry_default_model(entry)` → `metadata[:default_model]`
+- `enabled: false` on an instance config prevents registration — checked in `register_provider_instance`
+- `PROVIDER_DEFAULT_MODEL` does NOT belong in legion-llm — each provider owns its default in its own extension
+- Inventory calls `native_provider_offerings` (full metadata) and excludes `discovery_offerings` for providers with native adapters
+
+## Metering Spool
+
+- Events spool to `~/.legionio/data/spool/metering/events.jsonl` when AMQP transport is unavailable
+- Thread-safe (SPOOL_MUTEX), capped at `settings[:metering][:spool][:max_events]` (default 10K)
+- `flush_spool` publishes spooled events when transport reconnects; `lex-llm-ledger` actor triggers it
+
+## Health Tracker
+
+- `deny_model(provider:, model:, instance:)` — permanently excludes a model from routing (in-memory, until restart)
+- Config errors (ValidationException, AccessDenied, marketplace) trigger deny instead of circuit breaker
+- Discovery connection failures report `:error` to health tracker — circuit opens after threshold
+
 ---
 
 **Maintained By**: Matthew Iverson (@Esity)

--- a/lib/legion/llm/api/native/inference.rb
+++ b/lib/legion/llm/api/native/inference.rb
@@ -108,7 +108,7 @@ module Legion
                 id:              request_id,
                 messages:        messages,
                 system:          body[:system],
-                routing:         { provider: provider, model: model },
+                routing:         { provider: provider, model: model, instance: body[:instance] }.compact,
                 tools:           tool_declarations,
                 caller:          effective_caller,
                 conversation_id: conversation_id,

--- a/lib/legion/llm/api/native/models.rb
+++ b/lib/legion/llm/api/native/models.rb
@@ -92,7 +92,7 @@ module Legion
             summaries = offerings.group_by { |offering| offering[:model] }.map do |model, rows|
               summarize_model(model, rows)
             end
-            summaries.sort_by { |model| model[:id] }
+            summaries.sort_by { |model| [auto_routing_model?(model[:id]) ? 0 : 1, model[:id]] }
           end
 
           def self.summarize_model(model, offerings)

--- a/lib/legion/llm/api/native/models.rb
+++ b/lib/legion/llm/api/native/models.rb
@@ -9,6 +9,11 @@ module Legion
         module Models
           extend Legion::Logging::Helper
 
+          AUTO_ROUTING_MODEL_ID = 'legionio'
+          AUTO_ROUTING_MODEL_DISPLAY = 'LegionIO'
+          AUTO_ROUTING_OFFERING_ID = 'legionio:auto:inference:legionio'
+          AUTO_ROUTING_CAPABILITIES = %w[auto_routing chat completion json_schema tools].freeze
+
           def self.registered(app)
             log.debug('[llm][api][models] registering model inventory routes')
 
@@ -18,6 +23,7 @@ module Legion
 
               filters = Legion::LLM::API::Native::Models.request_filters(params)
               offerings = Legion::LLM::Inventory.offerings(filters)
+              offerings = Legion::LLM::API::Native::Models.with_auto_routing_offering(offerings, filters)
 
               json_response({
                               models:    Legion::LLM::API::Native::Models.model_summaries(offerings),
@@ -34,7 +40,9 @@ module Legion
               log.debug("[llm][api][models] action=get_model id=#{model_id}")
               require_llm!
 
-              offerings = Legion::LLM::Inventory.offerings(model: model_id)
+              filters = { model: model_id }
+              offerings = Legion::LLM::Inventory.offerings(filters)
+              offerings = Legion::LLM::API::Native::Models.with_auto_routing_offering(offerings, filters)
               halt json_error('model_not_found', "Model '#{model_id}' not found", status_code: 404) unless offerings.any?
 
               json_response({
@@ -88,7 +96,7 @@ module Legion
           end
 
           def self.summarize_model(model, offerings)
-            {
+            summary = {
               id:             model.to_s,
               types:          offerings.map { |offering| offering[:type].to_s }.uniq.sort,
               providers:      offerings.map { |offering| offering[:provider_family] }.uniq.sort,
@@ -99,6 +107,12 @@ module Legion
               max_context:    offerings.filter_map { |offering| offering.dig(:limits, :context_window) }.max,
               enabled:        offerings.any? { |offering| offering[:enabled] != false }
             }
+            if auto_routing_model?(model)
+              summary[:display_name] = AUTO_ROUTING_MODEL_DISPLAY
+              summary[:auto_route] = true
+              summary[:default] = true
+            end
+            summary
           end
 
           def self.summary(offerings)
@@ -109,6 +123,64 @@ module Legion
               by_type:         offerings.group_by { |offering| offering[:type].to_s }
                                         .transform_values(&:size)
             }
+          end
+
+          def self.with_auto_routing_offering(offerings, filters = {})
+            return offerings unless auto_routing_offering_matches?(filters)
+            return offerings if offerings.any? { |offering| auto_routing_model?(offering[:model]) }
+
+            [auto_routing_offering, *offerings]
+          end
+
+          def self.auto_routing_offering
+            {
+              id:                    AUTO_ROUTING_OFFERING_ID,
+              offering_id:           AUTO_ROUTING_OFFERING_ID,
+              model:                 AUTO_ROUTING_MODEL_ID,
+              display_name:          AUTO_ROUTING_MODEL_DISPLAY,
+              model_family:          'legionio',
+              canonical_model_alias: AUTO_ROUTING_MODEL_ID,
+              type:                  :inference,
+              provider_family:       'legionio',
+              provider_instance:     'auto',
+              instance_id:           'auto',
+              tier:                  :auto,
+              transport:             :internal,
+              enabled:               true,
+              capabilities:          AUTO_ROUTING_CAPABILITIES,
+              limits:                {},
+              health:                { circuit_state: 'available' },
+              metadata:              { auto_route: true, placeholder: true, display_name: AUTO_ROUTING_MODEL_DISPLAY },
+              routing_metadata:      { strategy: 'auto' },
+              source:                'static'
+            }
+          end
+
+          def self.auto_routing_offering_matches?(filters)
+            normalized = request_filters(filters)
+            type = normalized[:type]
+            return false if type && !type.to_s.empty? && type.to_s != 'inference' && type.to_s != 'chat'
+
+            provider = normalized[:provider]
+            return false if provider && !provider.to_s.empty? && !%w[legionio auto].include?(provider.to_s.downcase)
+
+            instance = normalized[:instance_id]
+            return false if instance && !instance.to_s.empty? && !%w[auto legionio].include?(instance.to_s.downcase)
+
+            model = normalized[:model] || normalized[:offering_id]
+            return false if model && !model.to_s.empty? && !auto_routing_model?(model) && model.to_s != AUTO_ROUTING_OFFERING_ID
+
+            family = normalized[:model_family]
+            return false if family && !family.to_s.empty? && family.to_s.downcase != 'legionio'
+
+            capability = normalized[:capability]
+            return false if capability && !AUTO_ROUTING_CAPABILITIES.include?(capability.to_s)
+
+            true
+          end
+
+          def self.auto_routing_model?(model)
+            model.to_s.strip.downcase == AUTO_ROUTING_MODEL_ID
           end
         end
       end

--- a/lib/legion/llm/api/native/tiers.rb
+++ b/lib/legion/llm/api/native/tiers.rb
@@ -232,7 +232,8 @@ module Legion
             return 'unknown' unless tracker
 
             tracker.circuit_state(provider_name.to_sym, instance: instance_name.to_sym).to_s
-          rescue StandardError
+          rescue StandardError => e
+            log.debug "[llm][tiers] action=offering_instance_health provider=#{provider_name} instance=#{instance_name} error=#{e.class} — #{e.message}"
             'unknown'
           end
         end

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -122,12 +122,23 @@ module Legion
 
           def resolve_provider
             LLM.embedding_provider ||
-              Legion::LLM::Settings.value(:embedding, :provider)&.to_sym
+              embedding_config_value(:provider)&.to_sym
           end
 
           def resolve_model
             LLM.embedding_model ||
-              Legion::LLM::Settings.value(:embedding, :default_model)
+              embedding_config_value(:default_model)
+          end
+
+          def embedding_config_value(key)
+            v = Legion::LLM::Settings.value(:embedding, key)
+            return v unless v.nil?
+
+            plural = Legion::LLM::Settings.value(:embeddings, key)
+            if !plural.nil?
+              log.warn "[llm][embeddings] settings key \"embeddings.#{key}\" (plural) is deprecated — rename to \"embedding.#{key}\""
+            end
+            plural
           end
 
           def coerce_text(value)

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -135,9 +135,7 @@ module Legion
             return v unless v.nil?
 
             plural = Legion::LLM::Settings.value(:embeddings, key)
-            if !plural.nil?
-              log.warn "[llm][embeddings] settings key \"embeddings.#{key}\" (plural) is deprecated — rename to \"embedding.#{key}\""
-            end
+            log.warn "[llm][embeddings] settings key \"embeddings.#{key}\" (plural) is deprecated — rename to \"embedding.#{key}\"" unless plural.nil?
             plural
           end
 

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -272,11 +272,14 @@ module Legion
 
           str_key = key.to_s
           obj[key]
-        rescue TypeError, NoMethodError, KeyError
+        rescue TypeError, NoMethodError, KeyError => e
+          log.debug "[llm][adapter] action=defined_method_access key=#{key} class=#{obj.class} " \
+                    "fallback=string_key error=#{e.class}: #{e.message}"
           begin
             obj[str_key]
-          rescue TypeError, NoMethodError, KeyError
-            log.debug "[llm][adapter] action=defined_method_access key=#{key} class=#{obj.class} — no accessor, no [] support, returning nil"
+          rescue TypeError, NoMethodError, KeyError => fallback_error
+            log.debug "[llm][adapter] action=defined_method_access key=#{key} class=#{obj.class} " \
+                      "fallback=none error=#{fallback_error.class}: #{fallback_error.message}"
             nil
           end
         end

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -257,6 +257,10 @@ module Legion
         end
 
         def defined_method_access(obj, key)
+          # Prefer named accessor (covers Data structs like Types::ContentBlock).
+          key_sym = key.respond_to?(:to_sym) ? key.to_sym : key
+          return obj.public_send(key_sym) if obj.respond_to?(key_sym)
+
           obj[key]
         rescue TypeError, NoMethodError, KeyError
           begin

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -248,7 +248,16 @@ module Legion
             return normalized[:text].to_s
           end
 
-          # Data structs and other objects with [] / fetch access (e.g. Types::ContentBlock)
+          # Data structs expose named readers (type/text) without necessarily implementing [].
+          # Try named accessor path first; fall through to [] / fetch for plain hashes/structs.
+          if part.respond_to?(:type) || part.respond_to?(:text)
+            type = (part.respond_to?(:type) ? part.type.to_s : '')
+            text = part.respond_to?(:text) ? part.text : nil
+            return text.to_s if type == 'text' || (type.empty? && !text.nil?)
+
+            return nil
+          end
+
           return unless part.respond_to?(:[]) || part.respond_to?(:fetch)
 
           type = (defined_method_access(part, :type) || '').to_s

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -239,12 +239,31 @@ module Legion
         end
 
         def text_part_content(part)
-          return unless part.respond_to?(:transform_keys)
+          return part if part.is_a?(String)
 
-          normalized = part.transform_keys { |key| key.respond_to?(:to_sym) ? key.to_sym : key }
-          return unless normalized[:type].to_s == 'text'
+          if part.respond_to?(:transform_keys)
+            normalized = part.transform_keys { |key| key.respond_to?(:to_sym) ? key.to_sym : key }
+            return unless normalized[:type].to_s == 'text'
 
-          normalized[:text].to_s
+            return normalized[:text].to_s
+          end
+
+          # Data structs and other objects with [] / fetch access (e.g. Types::ContentBlock)
+          return unless part.respond_to?(:[]) || part.respond_to?(:fetch)
+
+          type = (defined_method_access(part, :type) || '').to_s
+          text = defined_method_access(part, :text)
+          text.to_s if type == 'text' || (type.empty? && !text.nil?)
+        end
+
+        def defined_method_access(obj, key)
+          obj[key]
+        rescue TypeError, NoMethodError, KeyError
+          begin
+            obj[key.to_s]
+          rescue TypeError, NoMethodError, KeyError
+            nil
+          end
         end
 
         def normalize_message_tool_calls(tool_calls)

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -261,11 +261,13 @@ module Legion
           key_sym = key.respond_to?(:to_sym) ? key.to_sym : key
           return obj.public_send(key_sym) if obj.respond_to?(key_sym)
 
+          str_key = key.to_s
           obj[key]
         rescue TypeError, NoMethodError, KeyError
           begin
-            obj[key.to_s]
+            obj[str_key]
           rescue TypeError, NoMethodError, KeyError
+            log.debug "[llm][adapter] action=defined_method_access key=#{key} class=#{obj.class} — no accessor, no [] support, returning nil"
             nil
           end
         end

--- a/lib/legion/llm/call/providers.rb
+++ b/lib/legion/llm/call/providers.rb
@@ -52,7 +52,8 @@ module Legion
           Legion::Extensions::Llm.constants(false).filter_map do |const_name|
             mod = Legion::Extensions::Llm.const_get(const_name, false)
             provider_module?(mod) ? mod : nil
-          rescue NameError
+          rescue NameError => e
+            log.debug "[llm][providers] action=discover_provider_modules const=#{const_name} error=#{e.class} — #{e.message}"
             nil
           end
         end
@@ -120,7 +121,8 @@ module Legion
           return nil unless provider_module&.const_defined?(:PROVIDER_FAMILY, false)
 
           provider_module::PROVIDER_FAMILY
-        rescue StandardError
+        rescue StandardError => e
+          log.debug "[llm][providers] action=safe_provider_family error=#{e.class} — #{e.message}"
           nil
         end
 

--- a/lib/legion/llm/context/curator.rb
+++ b/lib/legion/llm/context/curator.rb
@@ -431,7 +431,8 @@ module Legion
         def curated_payload(entry)
           parsed = Legion::JSON.parse(entry[:content].to_s)
           parsed.is_a?(Hash) ? parsed : {}
-        rescue Legion::JSON::ParseError
+        rescue Legion::JSON::ParseError => e
+          log.debug "[llm][curator] action=curated_payload conversation_id=#{@conversation_id} error=#{e.class} — #{e.message}"
           {}
         end
 

--- a/lib/legion/llm/context/curator.rb
+++ b/lib/legion/llm/context/curator.rb
@@ -76,6 +76,8 @@ module Legion
           return msg if content.length <= max_chars
 
           summary = heuristic_tool_summary(content, tool_name_from(msg))
+          log.debug "[llm][curator] action=distill_tool_result conversation_id=#{@conversation_id} " \
+                    "original_chars=#{content.length} summary_chars=#{summary.length}"
           msg.merge(content: summary, curated: true, original_content: content)
         end
 
@@ -89,6 +91,8 @@ module Legion
 
           return msg if stripped == content || stripped.empty?
 
+          log.debug "[llm][curator] action=strip_thinking conversation_id=#{@conversation_id} " \
+                    "original_chars=#{content.length} stripped_chars=#{stripped.length}"
           msg.merge(content: stripped, curated: true, original_content: content)
         end
 

--- a/lib/legion/llm/context/curator.rb
+++ b/lib/legion/llm/context/curator.rb
@@ -9,9 +9,15 @@ module Legion
       class Curator
         include Legion::Logging::Helper
 
-        CURATED_KEY    = :__curated__
-        THINKING_OPEN  = '<thinking>'
-        THINKING_CLOSE = '</thinking>'
+        CURATED_KEY = :__curated__
+
+        # All known provider thinking tag variants.
+        # Anthropic: <thinking>…</thinking>
+        # DeepSeek / Qwen / Ollama / vLLM inline: <think>…</think>
+        THINKING_TAG_PAIRS = [
+          ['<thinking>', '</thinking>'],
+          ['<think>',    '</think>']
+        ].freeze
 
         def initialize(conversation_id:)
           @conversation_id = conversation_id
@@ -196,18 +202,27 @@ module Legion
         end
 
         def strip_thinking_tags(text)
-          result = +''
+          result = text
+          THINKING_TAG_PAIRS.each do |open_tag, close_tag|
+            result = strip_tag_pair(result, open_tag, close_tag)
+          end
+          result
+        end
+
+        def strip_tag_pair(text, open_tag, close_tag)
+          out = +''
           pos = 0
           while pos < text.length
-            open_idx = text.index(THINKING_OPEN, pos)
+            open_idx = text.index(open_tag, pos)
             break unless open_idx
 
-            result << text[pos...open_idx]
-            close_idx = text.index(THINKING_CLOSE, open_idx + THINKING_OPEN.length)
-            pos = close_idx ? close_idx + THINKING_CLOSE.length : text.length
+            out << text[pos...open_idx]
+            close_idx = text.index(close_tag, open_idx + open_tag.length)
+            pos = close_idx ? close_idx + close_tag.length : text.length
           end
-          result << text[pos..] if pos < text.length
-          result
+          out << text[pos..] if pos < text.length
+          # Strip any unclosed open tag left at the end (provider died mid-stream).
+          out.sub(/#{Regexp.escape(open_tag)}.*\z/m, '').strip
         end
 
         def curate_message(msg, assistant_response)

--- a/lib/legion/llm/discovery.rb
+++ b/lib/legion/llm/discovery.rb
@@ -257,7 +257,7 @@ module Legion
           provider  = best[:provider]
           instance  = best[:instance]
           resolved  = best.dig(:metadata, :default_model) ||
-                      Settings.value(:embedding, :default_model) ||
+                      embedding_settings[:default_model] ||
                       first_embedding_model_for(provider, instance)
 
           unless resolved.to_s.length.positive?
@@ -292,9 +292,10 @@ module Legion
         end
 
         def first_embedding_model_for(provider, instance)
+          embedding_caps = %w[embedding embeddings embed].freeze
           cached_discovered_models.find do |m|
             m[:provider].to_s == provider.to_s && m[:instance].to_s == instance.to_s &&
-              Array(m[:capabilities]).intersect?(%i[embedding embeddings embed])
+              Array(m[:capabilities]).any? { |c| embedding_caps.include?(c.to_s) }
           end&.dig(:model)
         end
 

--- a/lib/legion/llm/discovery.rb
+++ b/lib/legion/llm/discovery.rb
@@ -413,7 +413,17 @@ module Legion
         end
 
         def embedding_settings
-          Legion::LLM::Settings.config_value(llm_settings, :embedding, {})
+          settings = llm_settings
+          result = Legion::LLM::Settings.config_value(settings, :embedding)
+          return result if result.is_a?(Hash) && !result.empty?
+
+          plural = Legion::LLM::Settings.config_value(settings, :embeddings)
+          if plural.is_a?(Hash) && !plural.empty?
+            log.warn '[llm][discovery] settings key "embeddings" (plural) is deprecated — rename to "embedding" (singular)'
+            return plural
+          end
+
+          result || {}
         end
 
         def providers_settings

--- a/lib/legion/llm/discovery.rb
+++ b/lib/legion/llm/discovery.rb
@@ -261,7 +261,8 @@ module Legion
                       first_embedding_model_for(provider, instance)
 
           unless resolved.to_s.length.positive?
-            log.debug "[llm][discovery] action=detect_embedding_from_registry no_model_resolved provider=#{provider} instance=#{instance} — falling through to legacy probe"
+            log.debug '[llm][discovery] action=detect_embedding_from_registry no_model_resolved ' \
+                      "provider=#{provider} instance=#{instance} — falling through to legacy probe"
             return false
           end
 
@@ -293,7 +294,7 @@ module Legion
         def first_embedding_model_for(provider, instance)
           cached_discovered_models.find do |m|
             m[:provider].to_s == provider.to_s && m[:instance].to_s == instance.to_s &&
-              (Array(m[:capabilities]) & %i[embedding embeddings embed]).any?
+              Array(m[:capabilities]).intersect?(%i[embedding embeddings embed])
           end&.dig(:model)
         end
 

--- a/lib/legion/llm/discovery.rb
+++ b/lib/legion/llm/discovery.rb
@@ -254,11 +254,21 @@ module Legion
           end
           return false unless best
 
-          @embedding_provider = best[:provider]
-          @embedding_model = best.dig(:metadata, :default_model) ||
-                             Settings.value(:embedding, :default_model)
-          @embedding_instance = best[:instance]
-          @can_embed = true
+          provider  = best[:provider]
+          instance  = best[:instance]
+          resolved  = best.dig(:metadata, :default_model) ||
+                      Settings.value(:embedding, :default_model) ||
+                      first_embedding_model_for(provider, instance)
+
+          unless resolved.to_s.length.positive?
+            log.debug "[llm][discovery] action=detect_embedding_from_registry no_model_resolved provider=#{provider} instance=#{instance} — falling through to legacy probe"
+            return false
+          end
+
+          @embedding_provider = provider
+          @embedding_model    = resolved
+          @embedding_instance = instance
+          @can_embed          = true
           @embedding_fallback_chain = build_registry_embedding_fallback(embedding_instances)
 
           log.info "[llm][discovery] embedding available provider=#{@embedding_provider} " \
@@ -278,6 +288,13 @@ module Legion
               instance: i[:instance]
             }
           end
+        end
+
+        def first_embedding_model_for(provider, instance)
+          cached_discovered_models.find do |m|
+            m[:provider].to_s == provider.to_s && m[:instance].to_s == instance.to_s &&
+              (Array(m[:capabilities]) & %i[embedding embeddings embed]).any?
+          end&.dig(:model)
         end
 
         def find_embedding_provider(embedding_settings)

--- a/lib/legion/llm/discovery/rule_generator.rb
+++ b/lib/legion/llm/discovery/rule_generator.rb
@@ -152,7 +152,7 @@ module Legion
           normalized = DEFAULT_TIER_PRIORITY if normalized.empty?
           (normalized + DEFAULT_TIER_PRIORITY).uniq
         rescue StandardError => e
-          handle_exception(e, level: :debug, handled: true, operation: 'rule_generator.tier_priority')
+          handle_exception(e, level: :warn, handled: true, operation: 'rule_generator.tier_priority')
           DEFAULT_TIER_PRIORITY
         end
 

--- a/lib/legion/llm/discovery/rule_generator.rb
+++ b/lib/legion/llm/discovery/rule_generator.rb
@@ -26,7 +26,7 @@ module Legion
           anthropic: :frontier
         }.freeze
 
-        TIER_WEIGHT = { local: 100, fleet: 80, cloud: 60, frontier: 40 }.freeze
+        DEFAULT_TIER_PRIORITY = %i[local direct fleet openai_compat cloud frontier].freeze
 
         module_function
 
@@ -50,7 +50,7 @@ module Legion
                              extract_field(model_data, 'tier')&.to_sym ||
                              tier
                 capability = embedding_model?(model_data) ? :embed : :chat
-                priority = (TIER_WEIGHT[model_tier] || 80) - order
+                priority = tier_weight(model_tier) - order
                 rules << build_rule(provider, instance_id, model_data, capability, model_tier, priority)
                 rules << build_rule(provider, instance_id, model_data, :stream, model_tier, priority) if capability == :chat
                 order += 1
@@ -91,7 +91,7 @@ module Legion
             next unless default_model
 
             model_data = { name: default_model }
-            priority = TIER_WEIGHT[tier] || 40
+            priority = tier_weight(tier)
             rules << build_rule(provider_name, :default, model_data, :chat, tier, priority)
             rules << build_rule(provider_name, :default, model_data, :stream, tier, priority)
           end
@@ -134,6 +134,26 @@ module Legion
           return nil unless model_data.is_a?(Hash)
 
           model_data[field] || model_data[field.to_s]
+        end
+
+        def tier_weight(tier)
+          tier_sym = tier.respond_to?(:to_sym) ? tier.to_sym : tier
+          index = tier_priority.index(tier_sym)
+          return 0 unless index
+
+          (tier_priority.length - index) * 100
+        end
+
+        def tier_priority
+          configured = Legion::LLM::Settings.value(:routing, :tier_priority, default: DEFAULT_TIER_PRIORITY)
+          normalized = Array(configured).filter_map do |tier|
+            tier.to_sym if tier.respond_to?(:to_sym)
+          end
+          normalized = DEFAULT_TIER_PRIORITY if normalized.empty?
+          (normalized + DEFAULT_TIER_PRIORITY).uniq
+        rescue StandardError => e
+          handle_exception(e, level: :debug, handled: true, operation: 'rule_generator.tier_priority')
+          DEFAULT_TIER_PRIORITY
         end
 
         def extension_providers

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -375,16 +375,22 @@ module Legion
         end
 
         def routing_request_state
+          routing_explicit = @request.extra[:routing_explicit]
+          instance = @request.routing[:instance] || @request.routing[:instance_id] || @request.routing[:provider_instance]
+          tier = @request.extra[:tier]
           {
             provider:          @request.routing[:provider],
-            instance:          @request.routing[:instance] || @request.routing[:instance_id] || @request.routing[:provider_instance],
+            instance:          instance,
             model:             @request.routing[:model],
             offering_id:       @request.routing[:offering_id] || @request.routing[:id],
             offering_metadata: normalize_offering_metadata(@request.routing[:offering_metadata] ||
                                                            @request.routing[:offering]),
             intent:            @request.extra[:intent],
-            tier:              @request.extra[:tier],
-            auto_route:        @request.extra[:auto_route]
+            tier:              tier,
+            auto_route:        @request.extra[:auto_route],
+            provider_explicit: routing_field_explicit?(routing_explicit, :provider, @request.routing[:provider]),
+            instance_explicit: routing_field_explicit?(routing_explicit, :instance, instance),
+            tier_explicit:     routing_field_explicit?(routing_explicit, :tier, tier)
           }
         end
 
@@ -393,21 +399,25 @@ module Legion
           # caller-supplied tier/intent. Advisory assignments only fill blanks.
           if @proactive_tier_assignment&.dig(:forced)
             state[:tier] = @proactive_tier_assignment[:tier]
+            state[:tier_explicit] = true
             state[:intent] = merge_routing_intent(state[:intent], @proactive_tier_assignment[:intent])
             log.info "[llm][routing] action=forced_tier source=#{@proactive_tier_assignment[:source]} tier=#{state[:tier]}"
           elsif @proactive_tier_assignment && !state[:tier] && !state[:intent] && !state[:instance] &&
                 !state[:provider] && !state[:model]
             state[:tier] = @proactive_tier_assignment[:tier]
+            state[:tier_explicit] = true
             state[:intent] = @proactive_tier_assignment[:intent]
           end
           state
         end
 
         def resolve_routing_state(state)
-          explicit = state[:provider] || state[:instance] || state[:model]
+          return state unless defined?(Router)
+
+          explicit_route = state[:provider_explicit] || state[:instance_explicit] || state[:tier_explicit]
           auto_route = state[:auto_route] == true
-          return state unless (state[:intent] || state[:tier] || explicit || auto_route) && defined?(Router)
-          return state unless auto_route || Router.routing_enabled?
+          intent_route = state[:intent] && Router.routing_enabled?
+          return state unless explicit_route || auto_route || intent_route
 
           resolution = routing_resolution_for(state)
           return state unless resolution
@@ -416,7 +426,7 @@ module Legion
         end
 
         def routing_resolution_for(state)
-          if state[:auto_route] == true || pipeline_escalation_enabled?
+          if state[:auto_route] == true || (state[:intent] && pipeline_escalation_enabled?)
             @escalation_chain = Router.resolve_chain(
               intent:                 state[:intent],
               tier:                   state[:tier],
@@ -455,6 +465,13 @@ module Legion
             duration_ms: 0, timestamp: Time.now
           }
           state
+        end
+
+        def routing_field_explicit?(flags, key, value)
+          return false if value.nil? || value.to_s.empty?
+          return true unless flags.is_a?(Hash)
+
+          flags.fetch(key, flags.fetch(key.to_s, true)) == true
         end
 
         def step_request_normalization

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -330,7 +330,7 @@ module Legion
           @resolved_provider = state[:provider] ||
                                (state[:model] && Router.infer_provider_for_model(state[:model])) ||
                                llm_setting(:default_provider)
-          @resolved_instance = state[:instance] || llm_setting(:default_instance)
+          @resolved_instance = resolve_provider_instance(state[:instance], @resolved_provider)
           @resolved_model = state[:model] || llm_setting(:default_model)
           @resolved_tier = state[:tier]&.to_sym || inferred_provider_tier(@resolved_provider)
           @resolved_offering_id = state[:offering_id]
@@ -345,6 +345,26 @@ module Legion
             direction: :internal, detail: "routed to #{@resolved_provider}:#{@resolved_model}",
             from: 'router', to: 'pipeline'
           )
+        end
+
+        def resolve_provider_instance(requested_instance, provider)
+          return provider_scoped_instance(requested_instance, provider, preserve_unknown: true) if requested_instance
+
+          provider_scoped_instance(llm_setting(:default_instance), provider, preserve_unknown: false)
+        end
+
+        def provider_scoped_instance(instance, provider, preserve_unknown:)
+          return nil if instance.nil? || instance.to_s.empty? || provider.nil? || provider.to_s.empty?
+
+          provider_sym = provider.to_sym
+          instance_sym = instance.to_sym
+          return instance_sym if Call::Registry.registered?(provider_sym, instance: instance_sym)
+          return nil if Call::Registry.registered?(provider_sym)
+
+          preserve_unknown ? instance_sym : nil
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: 'llm.pipeline.provider_scoped_instance')
+          preserve_unknown ? instance : nil
         end
 
         def routing_request_state

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -490,49 +490,8 @@ module Legion
           chain.each do |resolution|
             next if tried.any? { |t| t[:provider] == resolution.provider && t[:instance] == resolution.instance && t[:model] == resolution.model }
 
-            move_type = if tried.empty?
-                          :primary
-                        elsif resolution.tier == primary_tier
-                          :lateral
-                        else
-                          :escalation
-                        end
-            log.info "[llm][escalation] action=attempt move=#{move_type} provider=#{resolution.provider} model=#{resolution.model} tier=#{resolution.tier}"
-
-            start_time = Time.now
-            @resolved_provider = resolution.provider
-            @resolved_instance = resolution.instance
-            @resolved_model = resolution.model
-            @resolved_tier = resolution.tier
-            @resolved_offering_id = resolution.offering_id
-            @resolved_offering_metadata = resolution.offering_metadata
-            succeeded = attempt_escalation(resolution, threshold, quality_check, start_time)
+            succeeded = run_escalation_resolution(resolution, threshold, quality_check, tried, primary_tier)
             break if succeeded
-            # Quality failure: record as tried so the same resolution is not re-attempted via a
-            # different position in the chain (de-dup), but it may still appear later in the chain
-            # if the caller built the chain with repetition.
-            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
-          rescue Legion::LLM::AuthError, Legion::LLM::PrivacyModeError => e
-            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
-            record_escalation_failure(e, resolution, start_time,
-                                      outcome: :auth_error, operation: 'llm.pipeline.escalation_attempt.auth',
-                                      handled: true)
-          rescue Legion::LLM::ContextOverflow => e
-            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
-            record_escalation_failure(e, resolution, start_time,
-                                      outcome: :context_overflow, operation: 'llm.pipeline.escalation_attempt.context_overflow',
-                                      handled: true)
-            log.warn "[llm][escalation] context_overflow provider=#{resolution.provider} model=#{resolution.model} — skipping same-tier, seeking larger context window"
-            skip_same_tier!(resolution, tried)
-          rescue Legion::LLM::RateLimitError => e
-            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
-            record_escalation_failure(e, resolution, start_time,
-                                      outcome: :rate_limited, operation: 'llm.pipeline.escalation_attempt.rate_limit',
-                                      handled: true)
-          rescue StandardError => e
-            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
-            record_escalation_failure(e, resolution, start_time, outcome:   :error,
-                                                                 operation: 'llm.pipeline.escalation_attempt')
           end
           return if succeeded
 
@@ -541,6 +500,58 @@ module Legion
             status: 'escalation_exhausted'
           )
           raise EscalationExhausted, "All #{@escalation_history.size} escalation attempts failed"
+        end
+
+        def run_escalation_resolution(resolution, threshold, quality_check, tried, primary_tier)
+          move_type = if tried.empty?
+                        :primary
+                      elsif resolution.tier == primary_tier
+                        :lateral
+                      else
+                        :escalation
+                      end
+          log.info "[llm][escalation] action=attempt move=#{move_type} provider=#{resolution.provider} model=#{resolution.model} tier=#{resolution.tier}"
+
+          start_time = Time.now
+          @resolved_provider = resolution.provider
+          @resolved_instance = resolution.instance
+          @resolved_model = resolution.model
+          @resolved_tier = resolution.tier
+          @resolved_offering_id = resolution.offering_id
+          @resolved_offering_metadata = resolution.offering_metadata
+          succeeded = attempt_escalation(resolution, threshold, quality_check, start_time)
+          tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model } unless succeeded
+          succeeded
+        rescue Legion::LLM::AuthError, Legion::LLM::PrivacyModeError => e
+          tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
+          record_escalation_failure(e, resolution, start_time,
+                                    outcome:   :auth_error,
+                                    operation: 'llm.pipeline.escalation_attempt.auth',
+                                    handled:   true)
+          false
+        rescue Legion::LLM::ContextOverflow => e
+          tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
+          record_escalation_failure(e, resolution, start_time,
+                                    outcome:   :context_overflow,
+                                    operation: 'llm.pipeline.escalation_attempt.context_overflow',
+                                    handled:   true)
+          log.warn "[llm][escalation] context_overflow provider=#{resolution.provider} " \
+                   "model=#{resolution.model} — skipping same-tier, seeking larger context window"
+          skip_same_tier!(resolution, tried)
+          false
+        rescue Legion::LLM::RateLimitError => e
+          tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
+          record_escalation_failure(e, resolution, start_time,
+                                    outcome:   :rate_limited,
+                                    operation: 'llm.pipeline.escalation_attempt.rate_limit',
+                                    handled:   true)
+          false
+        rescue StandardError => e
+          tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
+          record_escalation_failure(e, resolution, start_time,
+                                    outcome:   :error,
+                                    operation: 'llm.pipeline.escalation_attempt')
+          false
         end
 
         def attempt_escalation(resolution, threshold, quality_check, start_time)
@@ -617,9 +628,11 @@ module Legion
 
         def build_default_escalation_chain
           primary = Router.explicit_resolution(@resolved_tier, @resolved_provider, @resolved_model, @resolved_instance)
-          fallbacks = build_fallback_resolutions(exclude_provider: @resolved_provider,
-                                                 exclude_instance: @resolved_instance,
-                                                 primary_tier: @resolved_tier)
+          fallbacks = build_fallback_resolutions(
+            exclude_provider: @resolved_provider,
+            exclude_instance: @resolved_instance,
+            primary_tier:     @resolved_tier
+          )
           resolutions = ([primary] + fallbacks).compact.uniq { |r| [r.provider, r.instance, r.model] }
           Router::EscalationChain.new(resolutions: resolutions, max_attempts: pipeline_escalation_max_attempts)
         end

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -376,7 +376,8 @@ module Legion
             offering_metadata: normalize_offering_metadata(@request.routing[:offering_metadata] ||
                                                            @request.routing[:offering]),
             intent:            @request.extra[:intent],
-            tier:              @request.extra[:tier]
+            tier:              @request.extra[:tier],
+            auto_route:        @request.extra[:auto_route]
           }
         end
 
@@ -397,7 +398,9 @@ module Legion
 
         def resolve_routing_state(state)
           explicit = state[:provider] || state[:instance] || state[:model]
-          return state unless (state[:intent] || state[:tier] || explicit) && defined?(Router) && Router.routing_enabled?
+          auto_route = state[:auto_route] == true
+          return state unless (state[:intent] || state[:tier] || explicit || auto_route) && defined?(Router)
+          return state unless auto_route || Router.routing_enabled?
 
           resolution = routing_resolution_for(state)
           return state unless resolution
@@ -406,7 +409,7 @@ module Legion
         end
 
         def routing_resolution_for(state)
-          if pipeline_escalation_enabled?
+          if state[:auto_route] == true || pipeline_escalation_enabled?
             @escalation_chain = Router.resolve_chain(
               intent:          state[:intent],
               tier:            state[:tier],

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -482,9 +482,23 @@ module Legion
           threshold = pipeline_escalation_quality_threshold
           quality_check = @request.extra[:quality_check]
           succeeded = false
+          tried = []
           log.debug "[llm][executor] action=escalation.enter chain_size=#{chain.size} threshold=#{threshold}"
 
+          primary_tier = @escalation_chain&.primary&.tier
+
           chain.each do |resolution|
+            next if tried.any? { |t| t[:provider] == resolution.provider && t[:instance] == resolution.instance && t[:model] == resolution.model }
+
+            move_type = if tried.empty?
+                          :primary
+                        elsif resolution.tier == primary_tier
+                          :lateral
+                        else
+                          :escalation
+                        end
+            log.info "[llm][escalation] action=attempt move=#{move_type} provider=#{resolution.provider} model=#{resolution.model} tier=#{resolution.tier}"
+
             start_time = Time.now
             @resolved_provider = resolution.provider
             @resolved_instance = resolution.instance
@@ -494,15 +508,29 @@ module Legion
             @resolved_offering_metadata = resolution.offering_metadata
             succeeded = attempt_escalation(resolution, threshold, quality_check, start_time)
             break if succeeded
+            # Quality failure: record as tried so the same resolution is not re-attempted via a
+            # different position in the chain (de-dup), but it may still appear later in the chain
+            # if the caller built the chain with repetition.
+            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
           rescue Legion::LLM::AuthError, Legion::LLM::PrivacyModeError => e
+            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
             record_escalation_failure(e, resolution, start_time,
                                       outcome: :auth_error, operation: 'llm.pipeline.escalation_attempt.auth',
                                       handled: true)
+          rescue Legion::LLM::ContextOverflow => e
+            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
+            record_escalation_failure(e, resolution, start_time,
+                                      outcome: :context_overflow, operation: 'llm.pipeline.escalation_attempt.context_overflow',
+                                      handled: true)
+            log.warn "[llm][escalation] context_overflow provider=#{resolution.provider} model=#{resolution.model} — skipping same-tier, seeking larger context window"
+            skip_same_tier!(resolution, tried)
           rescue Legion::LLM::RateLimitError => e
+            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
             record_escalation_failure(e, resolution, start_time,
                                       outcome: :rate_limited, operation: 'llm.pipeline.escalation_attempt.rate_limit',
                                       handled: true)
           rescue StandardError => e
+            tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
             record_escalation_failure(e, resolution, start_time, outcome:   :error,
                                                                  operation: 'llm.pipeline.escalation_attempt')
           end
@@ -588,12 +616,50 @@ module Legion
         end
 
         def build_default_escalation_chain
-          Router.resolve_chain(
-            provider:        @resolved_provider,
-            instance:        @resolved_instance,
-            model:           @resolved_model,
-            max_escalations: pipeline_escalation_max_attempts
-          )
+          primary = Router.explicit_resolution(@resolved_tier, @resolved_provider, @resolved_model, @resolved_instance)
+          fallbacks = build_fallback_resolutions(exclude_provider: @resolved_provider,
+                                                 exclude_instance: @resolved_instance,
+                                                 primary_tier: @resolved_tier)
+          resolutions = ([primary] + fallbacks).compact.uniq { |r| [r.provider, r.instance, r.model] }
+          Router::EscalationChain.new(resolutions: resolutions, max_attempts: pipeline_escalation_max_attempts)
+        end
+
+        def build_fallback_resolutions(exclude_provider: nil, exclude_instance: nil, primary_tier: nil)
+          tier_rank = Router::TIER_RANK
+          primary_rank = primary_tier ? (tier_rank[primary_tier.to_sym] || 99) : 99
+
+          candidates = Call::Registry.all_instances.filter_map do |entry|
+            next if entry[:provider] == exclude_provider&.to_sym && entry[:instance] == (exclude_instance&.to_sym || :default)
+            next if entry[:provider] == exclude_provider&.to_sym && exclude_instance.nil?
+
+            model = Router.send(:registry_default_model, entry)
+            next unless model
+
+            tier = Router::PROVIDER_TIER.fetch(entry[:provider], :frontier)
+            Router::Resolution.new(
+              tier:     tier,
+              provider: entry[:provider],
+              instance: entry[:instance] == :default ? nil : entry[:instance],
+              model:    model,
+              rule:     'escalation_fallback'
+            )
+          end
+
+          # Lateral alternatives (same tier) come first; escalations (higher tier) follow
+          candidates.sort_by { |r| [(tier_rank[r.tier] || 99) <=> primary_rank, tier_rank[r.tier] || 99] }
+        end
+
+        def skip_same_tier!(failed_resolution, tried)
+          chain = @escalation_chain
+          return unless chain.respond_to?(:each)
+
+          chain.each do |r|
+            next if r.tier != failed_resolution.tier
+            next if tried.any? { |t| t[:provider] == r.provider && t[:instance] == r.instance && t[:model] == r.model }
+
+            log.debug "[llm][escalation] action=skip_same_tier provider=#{r.provider} model=#{r.model} tier=#{r.tier} reason=context_overflow"
+            tried << { provider: r.provider, instance: r.instance, model: r.model }
+          end
         end
 
         def escalation_attempt_hash(resolution, outcome:, failures:, duration_ms:)

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -588,7 +588,12 @@ module Legion
         end
 
         def build_default_escalation_chain
-          Router.resolve_chain(max_escalations: pipeline_escalation_max_attempts)
+          Router.resolve_chain(
+            provider:        @resolved_provider,
+            instance:        @resolved_instance,
+            model:           @resolved_model,
+            max_escalations: pipeline_escalation_max_attempts
+          )
         end
 
         def escalation_attempt_hash(resolution, outcome:, failures:, duration_ms:)

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -478,14 +478,15 @@ module Legion
         end
 
         def run_provider_call_with_escalation
-          chain = @escalation_chain || build_default_escalation_chain
+          @escalation_chain ||= build_default_escalation_chain
+          chain = @escalation_chain
           threshold = pipeline_escalation_quality_threshold
           quality_check = @request.extra[:quality_check]
           succeeded = false
           tried = []
           log.debug "[llm][executor] action=escalation.enter chain_size=#{chain.size} threshold=#{threshold}"
 
-          primary_tier = @escalation_chain&.primary&.tier
+          primary_tier = @escalation_chain.primary&.tier
 
           chain.each do |resolution|
             next if tried.any? { |t| t[:provider] == resolution.provider && t[:instance] == resolution.instance && t[:model] == resolution.model }

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -367,7 +367,7 @@ module Legion
             state[:tier] = @proactive_tier_assignment[:tier]
             state[:intent] = merge_routing_intent(state[:intent], @proactive_tier_assignment[:intent])
             log.info "[llm][routing] action=forced_tier source=#{@proactive_tier_assignment[:source]} tier=#{state[:tier]}"
-          elsif @proactive_tier_assignment && !state[:tier] && !state[:intent]
+          elsif @proactive_tier_assignment && !state[:tier] && !state[:intent] && !state[:instance]
             state[:tier] = @proactive_tier_assignment[:tier]
             state[:intent] = @proactive_tier_assignment[:intent]
           end
@@ -390,11 +390,13 @@ module Legion
               tier:            state[:tier],
               model:           state[:model],
               provider:        state[:provider],
+              instance:        state[:instance],
               max_escalations: pipeline_escalation_max_attempts
             )
             @escalation_chain.primary
           else
-            Router.resolve(intent: state[:intent], tier: state[:tier], model: state[:model], provider: state[:provider])
+            Router.resolve(intent: state[:intent], tier: state[:tier], model: state[:model],
+                           provider: state[:provider], instance: state[:instance])
           end
         end
 

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -161,7 +161,7 @@ module Legion
 
           Router::PROVIDER_TIER.fetch(provider.to_sym, nil) if defined?(Router::PROVIDER_TIER)
         rescue StandardError => e
-          handle_exception(e, level: :debug, handled: true, operation: 'llm.pipeline.inferred_provider_tier',
+          handle_exception(e, level: :warn, handled: true, operation: 'llm.pipeline.inferred_provider_tier',
                               provider: provider)
           nil
         end
@@ -328,12 +328,17 @@ module Legion
           log.debug "[llm][executor] action=step_routing.enter requested_provider=#{@request.routing[:provider]} requested_model=#{@request.routing[:model]}"
           @timestamps[:routing_start] = Time.now
           state = resolve_routing_state(apply_proactive_tier_assignment(routing_request_state))
+          auto_route = state[:auto_route] == true
 
           @resolved_provider = state[:provider] ||
                                (state[:model] && Router.infer_provider_for_model(state[:model])) ||
-                               llm_setting(:default_provider)
+                               (llm_setting(:default_provider) unless auto_route)
           @resolved_instance = resolve_provider_instance(state[:instance], @resolved_provider)
-          @resolved_model = state[:model] || llm_setting(:default_model)
+          @resolved_model = state[:model] || (llm_setting(:default_model) unless auto_route)
+          if auto_route && (@resolved_provider.nil? || @resolved_model.nil?)
+            raise ProviderError, 'Auto routing could not resolve an available LLM provider/model'
+          end
+
           @resolved_tier = state[:tier]&.to_sym || inferred_provider_tier(@resolved_provider)
           @resolved_offering_id = state[:offering_id]
           @resolved_offering_metadata = state[:offering_metadata]
@@ -413,12 +418,13 @@ module Legion
         def routing_resolution_for(state)
           if state[:auto_route] == true || pipeline_escalation_enabled?
             @escalation_chain = Router.resolve_chain(
-              intent:          state[:intent],
-              tier:            state[:tier],
-              model:           state[:model],
-              provider:        state[:provider],
-              instance:        state[:instance],
-              max_escalations: pipeline_escalation_max_attempts
+              intent:                 state[:intent],
+              tier:                   state[:tier],
+              model:                  state[:model],
+              provider:               state[:provider],
+              instance:               state[:instance],
+              max_escalations:        pipeline_escalation_max_attempts,
+              allow_default_fallback: state[:auto_route] != true
             )
             @escalation_chain.primary
           else

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -367,7 +367,8 @@ module Legion
             state[:tier] = @proactive_tier_assignment[:tier]
             state[:intent] = merge_routing_intent(state[:intent], @proactive_tier_assignment[:intent])
             log.info "[llm][routing] action=forced_tier source=#{@proactive_tier_assignment[:source]} tier=#{state[:tier]}"
-          elsif @proactive_tier_assignment && !state[:tier] && !state[:intent] && !state[:instance]
+          elsif @proactive_tier_assignment && !state[:tier] && !state[:intent] && !state[:instance] &&
+                !state[:provider] && !state[:model]
             state[:tier] = @proactive_tier_assignment[:tier]
             state[:intent] = @proactive_tier_assignment[:intent]
           end
@@ -375,7 +376,8 @@ module Legion
         end
 
         def resolve_routing_state(state)
-          return state unless (state[:intent] || state[:tier]) && defined?(Router) && Router.routing_enabled?
+          explicit = state[:provider] || state[:instance] || state[:model]
+          return state unless (state[:intent] || state[:tier] || explicit) && defined?(Router) && Router.routing_enabled?
 
           resolution = routing_resolution_for(state)
           return state unless resolution
@@ -659,8 +661,20 @@ module Legion
             )
           end
 
-          # Lateral alternatives (same tier) come first; escalations (higher tier) follow
-          candidates.sort_by { |r| [(tier_rank[r.tier] || 99) <=> primary_rank, tier_rank[r.tier] || 99] }
+          # Lateral alternatives (same tier) come first; escalations (higher tier) follow;
+          # lower-ranked tiers are appended last.
+          candidates.sort_by do |r|
+            r_rank = tier_rank[r.tier] || 99
+            rank_diff = r_rank - primary_rank
+            bucket = if rank_diff.zero?
+                       0
+                     elsif rank_diff.positive?
+                       1
+                     else
+                       2
+                     end
+            [bucket, r_rank]
+          end
         end
 
         def skip_same_tier!(failed_resolution, tried)

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -159,9 +159,11 @@ module Legion
           return meta[:tier].to_sym if meta.is_a?(Hash) && meta[:tier]
           return Router.provider_tier(provider) if defined?(Router) && Router.respond_to?(:provider_tier)
 
-          Router::PROVIDER_TIER.fetch(provider.to_sym, :cloud) if defined?(Router::PROVIDER_TIER)
-        rescue StandardError
-          :cloud
+          Router::PROVIDER_TIER.fetch(provider.to_sym, nil) if defined?(Router::PROVIDER_TIER)
+        rescue StandardError => e
+          handle_exception(e, level: :debug, handled: true, operation: 'llm.pipeline.inferred_provider_tier',
+                              provider: provider)
+          nil
         end
 
         def execute_steps

--- a/lib/legion/llm/inference/prompt.rb
+++ b/lib/legion/llm/inference/prompt.rb
@@ -41,6 +41,14 @@ module Legion
                      **)
           resolved_provider = provider
           resolved_model = model
+          auto_route = Inference::Request.auto_routing_model?(resolved_model)
+
+          if auto_route
+            resolved_provider = nil
+            intent ||= Inference::Request.default_auto_routing_intent
+          elsif resolved_provider.nil? && resolved_model && defined?(Router)
+            resolved_provider = Router.infer_provider_for_model(resolved_model)
+          end
 
           if resolved_provider.nil? && resolved_model.nil? && defined?(Router) && Router.routing_enabled? && (intent || tier)
             resolution = Router.resolve(intent: intent, tier: tier, exclude: exclude)
@@ -48,8 +56,8 @@ module Legion
             resolved_model = resolution&.model
           end
 
-          resolved_provider ||= llm_setting(:default_provider)
-          resolved_model ||= llm_setting(:default_model)
+          resolved_provider ||= llm_setting(:default_provider) unless auto_route
+          resolved_model ||= llm_setting(:default_model) unless auto_route
 
           request(message,
                   provider:        resolved_provider,
@@ -90,7 +98,8 @@ module Legion
                     cache: nil,
                     quality_check: nil,
                     **)
-          if provider.nil? || model.nil?
+          auto_route = Inference::Request.auto_routing_model?(model)
+          if !auto_route && (provider.nil? || model.nil?)
             raise LLMError, "Prompt.request: provider and model must be set (got provider=#{provider.inspect}, model=#{model.inspect}). " \
                             'Configure Legion::Settings[:llm][:default_provider] and [:default_model], or pass them explicitly.'
           end

--- a/lib/legion/llm/inference/prompt.rb
+++ b/lib/legion/llm/inference/prompt.rb
@@ -39,6 +39,7 @@ module Legion
                      cache: nil,
                      quality_check: nil,
                      **)
+          routing_explicit = { provider: !provider.nil?, model: !model.nil?, tier: !tier.nil? }
           resolved_provider = provider
           resolved_model = model
           auto_route = Inference::Request.auto_routing_model?(resolved_model)
@@ -60,22 +61,23 @@ module Legion
           resolved_model ||= llm_setting(:default_model) unless auto_route
 
           request(message,
-                  provider:        resolved_provider,
-                  model:           resolved_model,
-                  intent:          intent,
-                  tier:            tier,
-                  schema:          schema,
-                  tools:           tools,
-                  escalate:        escalate,
-                  max_escalations: max_escalations,
-                  thinking:        thinking,
-                  temperature:     temperature,
-                  max_tokens:      max_tokens,
-                  tracing:         tracing,
-                  agent:           agent,
-                  caller:          caller,
-                  cache:           cache,
-                  quality_check:   quality_check,
+                  provider:         resolved_provider,
+                  model:            resolved_model,
+                  intent:           intent,
+                  tier:             tier,
+                  schema:           schema,
+                  tools:            tools,
+                  escalate:         escalate,
+                  max_escalations:  max_escalations,
+                  thinking:         thinking,
+                  temperature:      temperature,
+                  max_tokens:       max_tokens,
+                  tracing:          tracing,
+                  agent:            agent,
+                  caller:           caller,
+                  cache:            cache,
+                  quality_check:    quality_check,
+                  routing_explicit: routing_explicit,
                   **)
         end
 

--- a/lib/legion/llm/inference/request.rb
+++ b/lib/legion/llm/inference/request.rb
@@ -3,6 +3,9 @@
 module Legion
   module LLM
     module Inference
+      AUTO_ROUTING_MODEL_KEY = 'legionio'
+      AUTO_ROUTING_MODEL_ALIASES = [AUTO_ROUTING_MODEL_KEY].freeze
+
       Request = ::Data.define(
         :id, :conversation_id, :idempotency_key, :schema_version,
         :system, :messages, :tools, :tool_choice,
@@ -14,6 +17,11 @@ module Legion
         :billing, :test, :modality, :hooks
       ) do
         def self.build(**kwargs)
+          routing, extra = normalize_auto_routing(
+            kwargs.fetch(:routing, { provider: nil, model: nil }),
+            kwargs.fetch(:extra, {})
+          )
+
           new(
             id:               kwargs[:id] || "req_#{SecureRandom.hex(12)}",
             conversation_id:  kwargs[:conversation_id],
@@ -23,7 +31,7 @@ module Legion
             messages:         kwargs.fetch(:messages, []),
             tools:            kwargs.key?(:tools) ? kwargs[:tools] : nil,
             tool_choice:      kwargs.fetch(:tool_choice, { mode: :auto }),
-            routing:          kwargs.fetch(:routing, { provider: nil, model: nil }),
+            routing:          routing,
             tokens:           kwargs.fetch(:tokens, { max: 4096 }),
             stop:             kwargs.fetch(:stop, { sequences: [] }),
             generation:       kwargs.fetch(:generation, {}),
@@ -35,7 +43,7 @@ module Legion
             cache:            kwargs.fetch(:cache, { strategy: :default, cacheable: true }),
             priority:         kwargs.fetch(:priority, :normal),
             ttl:              kwargs[:ttl],
-            extra:            kwargs.fetch(:extra, {}),
+            extra:            extra,
             metadata:         kwargs.fetch(:metadata, {}),
             enrichments:      kwargs.fetch(:enrichments, {}),
             predictions:      kwargs.fetch(:predictions, {}),
@@ -109,6 +117,41 @@ module Legion
           }
           build_args[:id] = request_id if request_id
           build(**build_args)
+        end
+
+        def self.auto_routing_model?(model)
+          Legion::LLM::Inference::AUTO_ROUTING_MODEL_ALIASES.include?(model.to_s.strip.downcase)
+        end
+
+        def self.default_auto_routing_intent
+          routing = Legion::LLM::Settings.value(:routing, default: {})
+          intent = Legion::LLM::Settings.config_value(routing, :default_intent, {})
+          intent = intent.is_a?(Hash) ? normalize_hash(intent) : {}
+          intent.merge(capability: :chat)
+        rescue StandardError
+          { capability: :chat }
+        end
+
+        def self.normalize_auto_routing(routing, extra)
+          normalized_routing = normalize_hash(routing)
+          normalized_extra = normalize_hash(extra)
+          return [normalized_routing, normalized_extra] unless auto_routing_model?(normalized_routing[:model])
+
+          normalized_routing = { provider: nil, model: nil }
+          normalized_extra = normalized_extra.dup
+          normalized_extra.delete(:tier)
+          normalized_extra[:intent] ||= default_auto_routing_intent
+          normalized_extra[:auto_route] = true
+          normalized_extra[:requested_model_alias] = Legion::LLM::Inference::AUTO_ROUTING_MODEL_KEY
+          [normalized_routing, normalized_extra]
+        end
+
+        def self.normalize_hash(value)
+          return {} unless value.is_a?(Hash)
+
+          value.each_with_object({}) do |(key, hash_value), normalized|
+            normalized[key.respond_to?(:to_sym) ? key.to_sym : key] = hash_value
+          end
         end
       end
     end

--- a/lib/legion/llm/inference/steps/rag_context.rb
+++ b/lib/legion/llm/inference/steps/rag_context.rb
@@ -319,6 +319,7 @@ module Legion
 
           def positive_integer(value)
             return nil if value.nil?
+            return nil if value.respond_to?(:empty?) && value.empty?
 
             integer = Integer(value)
             integer.positive? ? integer : nil

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -161,7 +161,7 @@ module Legion
                                   :anthropic
                               end
           resolved_model    = model || registry_default_model(registry_entry) || (tier && default_model_for_tier(tier))
-          resolved_instance = instance || registry_entry&.[](:instance)
+          resolved_instance = registry_entry&.[](:instance) || instance
           resolved_tier     = tier || PROVIDER_TIER.fetch(resolved_provider, :frontier)
 
           Resolution.new(

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -18,6 +18,7 @@ module Legion
                         gemini: :cloud, azure: :cloud, ollama: :local, vllm: :fleet }.freeze
       PROVIDER_ORDER = %i[ollama vllm bedrock azure gemini anthropic openai].freeze
       TIER_EXTERNAL = Set[:cloud, :frontier, :openai_compat].freeze
+      TIER_RANK = { local: 0, direct: 1, fleet: 2, openai_compat: 3, cloud: 4, frontier: 5 }.freeze
 
       OLLAMA_MODEL_PATTERN = %r{[:/]}
 
@@ -145,6 +146,34 @@ module Legion
           true
         end
 
+        def explicit_resolution(tier, provider, model, instance = nil)
+          registry_entry = if provider
+                             registry_entry_for_provider(provider.to_sym)
+                           elsif tier
+                             registry_entry_for_tier(tier)
+                           end
+          resolved_provider = if provider
+                               provider.to_sym
+                             else
+                               registry_entry&.[](:provider) ||
+                                 (tier && default_provider_for_tier(tier)) ||
+                                 default_settings_provider&.to_sym ||
+                                 :anthropic
+                             end
+          resolved_model    = model || registry_default_model(registry_entry) || (tier && default_model_for_tier(tier))
+          resolved_instance = instance || registry_entry&.[](:instance)
+          resolved_tier     = tier || PROVIDER_TIER.fetch(resolved_provider, :frontier)
+
+          Resolution.new(
+            tier:     resolved_tier,
+            provider: resolved_provider,
+            model:    resolved_model,
+            instance: resolved_instance,
+            rule:     'explicit',
+            metadata: registry_resolution_metadata(registry_entry)
+          )
+        end
+
         private
 
         def arbitrage_fallback(intent)
@@ -160,27 +189,6 @@ module Legion
           tier = PROVIDER_TIER.fetch(provider, :cloud)
           log.debug("Router: arbitrage fallback selected model=#{model} provider=#{provider} tier=#{tier}")
           Resolution.new(tier: tier, provider: provider, model: model, rule: 'arbitrage_fallback')
-        end
-
-        def explicit_resolution(tier, provider, model, instance = nil)
-          registry_entry = if provider
-                             registry_entry_for_provider(provider.to_sym)
-                           elsif tier
-                             registry_entry_for_tier(tier)
-                           end
-          resolved_provider = provider ? provider.to_sym : (registry_entry&.[](:provider) || default_provider_for_tier(tier))
-          resolved_model    = model || registry_default_model(registry_entry) || (tier && default_model_for_tier(tier))
-          resolved_instance = instance || registry_entry&.[](:instance)
-          resolved_tier     = tier || PROVIDER_TIER.fetch(resolved_provider, :frontier)
-
-          Resolution.new(
-            tier:     resolved_tier,
-            provider: resolved_provider,
-            model:    resolved_model,
-            instance: resolved_instance,
-            rule:     'explicit',
-            metadata: registry_resolution_metadata(registry_entry)
-          )
         end
 
         def merge_defaults(intent)
@@ -430,10 +438,13 @@ module Legion
             p = (provider || default_settings_provider)&.to_sym
             resolved_model = model || registry_default_model(registry_entry_for_provider(p)) ||
                              default_settings_model || 'claude-sonnet-4-6'
-            res = Resolution.new(tier:     PROVIDER_TIER.fetch(p, :frontier),
-                                 provider: p || :anthropic,
-                                 model:    resolved_model)
-            return EscalationChain.new(resolutions: [res], max_attempts: max)
+            primary = Resolution.new(tier:     PROVIDER_TIER.fetch(p || :anthropic, :frontier),
+                                     provider: p || :anthropic,
+                                     model:    resolved_model)
+            # Append remaining registered providers as fallbacks (sorted by tier rank)
+            fallbacks = enabled_provider_chain.reject { |r| r.provider == primary.provider }
+            resolutions = ([primary] + fallbacks).uniq { |r| [r.provider, r.instance, r.model] }
+            return EscalationChain.new(resolutions: resolutions, max_attempts: max)
           end
 
           resolutions = enabled_provider_chain

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -148,7 +148,7 @@ module Legion
 
         def explicit_resolution(tier, provider, model, instance = nil)
           registry_entry = if provider
-                             registry_entry_for_provider(provider.to_sym)
+                             registry_entry_for_provider(provider.to_sym, instance: instance&.to_sym)
                            elsif tier
                              registry_entry_for_tier(tier)
                            end
@@ -586,14 +586,23 @@ module Legion
         end
 
         # Find the first registered instance for a specific provider.
-        def registry_entry_for_provider(provider)
+        # When +instance+ is given, prefers the entry whose :instance matches;
+        # falls back to the first provider entry if no exact match is found.
+        def registry_entry_for_provider(provider, instance: nil)
           instances = begin
             Call::Registry.all_instances
           rescue StandardError => e
             handle_exception(e, level: :warn, handled: true, operation: 'router.registry_entry_for_provider')
             []
           end
-          instances.find { |entry| entry[:provider] == provider }
+          provider_entries = instances.select { |entry| entry[:provider] == provider }
+          return nil if provider_entries.empty?
+
+          if instance
+            provider_entries.find { |entry| entry[:instance] == instance } || provider_entries.first
+          else
+            provider_entries.first
+          end
         end
 
         # Find a default model from registry for a given tier.

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -60,9 +60,9 @@ module Legion
         # @param model    [String, nil] explicit model override
         # @param provider [Symbol, nil] explicit provider override
         # @return [Resolution, nil]
-        def resolve(intent: nil, tier: nil, model: nil, provider: nil, exclude: {})
-          log.debug "[llm][router] action=resolve.enter intent=#{intent} tier=#{tier} model=#{model} provider=#{provider}"
-          return explicit_resolution(tier, provider, model) if tier
+        def resolve(intent: nil, tier: nil, model: nil, provider: nil, instance: nil, exclude: {})
+          log.debug "[llm][router] action=resolve.enter intent=#{intent} tier=#{tier} model=#{model} provider=#{provider} instance=#{instance}"
+          return explicit_resolution(tier, provider, model, instance) if tier || provider || instance
 
           return nil unless routing_enabled? && intent
 
@@ -81,10 +81,10 @@ module Legion
           resolution || arbitrage_fallback(intent)
         end
 
-        def resolve_chain(intent: nil, tier: nil, model: nil, provider: nil, max_escalations: nil, exclude: {})
+        def resolve_chain(intent: nil, tier: nil, model: nil, provider: nil, instance: nil, max_escalations: nil, exclude: {})
           log.debug "[llm][router] action=resolve_chain.enter intent=#{intent} tier=#{tier} max_escalations=#{max_escalations}"
           max = max_escalations || escalation_max_attempts
-          return EscalationChain.new(resolutions: [explicit_resolution(tier, provider, model)], max_attempts: max) if tier
+          return EscalationChain.new(resolutions: [explicit_resolution(tier, provider, model, instance)], max_attempts: max) if tier || provider || instance
           return chain_from_defaults(model, provider, max) unless routing_enabled? && intent
 
           chain_from_intent(intent, max, exclude: exclude)
@@ -162,20 +162,22 @@ module Legion
           Resolution.new(tier: tier, provider: provider, model: model, rule: 'arbitrage_fallback')
         end
 
-        def explicit_resolution(tier, provider, model)
+        def explicit_resolution(tier, provider, model, instance = nil)
           registry_entry = if provider
                              registry_entry_for_provider(provider.to_sym)
-                           else
+                           elsif tier
                              registry_entry_for_tier(tier)
                            end
           resolved_provider = provider ? provider.to_sym : (registry_entry&.[](:provider) || default_provider_for_tier(tier))
-          resolved_model = model || registry_default_model(registry_entry) || default_model_for_tier(tier)
+          resolved_model    = model || registry_default_model(registry_entry) || (tier && default_model_for_tier(tier))
+          resolved_instance = instance || registry_entry&.[](:instance)
+          resolved_tier     = tier || PROVIDER_TIER.fetch(resolved_provider, :frontier)
 
           Resolution.new(
-            tier:     tier,
+            tier:     resolved_tier,
             provider: resolved_provider,
             model:    resolved_model,
-            instance: registry_entry&.[](:instance),
+            instance: resolved_instance,
             rule:     'explicit',
             metadata: registry_resolution_metadata(registry_entry)
           )

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -153,13 +153,13 @@ module Legion
                              registry_entry_for_tier(tier)
                            end
           resolved_provider = if provider
-                               provider.to_sym
-                             else
-                               registry_entry&.[](:provider) ||
-                                 (tier && default_provider_for_tier(tier)) ||
-                                 default_settings_provider&.to_sym ||
-                                 :anthropic
-                             end
+                                provider.to_sym
+                              else
+                                registry_entry&.[](:provider) ||
+                                  (tier && default_provider_for_tier(tier)) ||
+                                  default_settings_provider&.to_sym ||
+                                  :anthropic
+                              end
           resolved_model    = model || registry_default_model(registry_entry) || (tier && default_model_for_tier(tier))
           resolved_instance = instance || registry_entry&.[](:instance)
           resolved_tier     = tier || PROVIDER_TIER.fetch(resolved_provider, :frontier)

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -82,13 +82,14 @@ module Legion
           resolution || arbitrage_fallback(intent)
         end
 
-        def resolve_chain(intent: nil, tier: nil, model: nil, provider: nil, instance: nil, max_escalations: nil, exclude: {})
+        def resolve_chain(intent: nil, tier: nil, model: nil, provider: nil, instance: nil, max_escalations: nil,
+                          exclude: {}, allow_default_fallback: true)
           log.debug "[llm][router] action=resolve_chain.enter intent=#{intent} tier=#{tier} max_escalations=#{max_escalations}"
           max = max_escalations || escalation_max_attempts
           return EscalationChain.new(resolutions: [explicit_resolution(tier, provider, model, instance)], max_attempts: max) if tier || provider || instance
-          return chain_from_defaults(model, provider, max) unless routing_enabled? && intent
+          return chain_from_defaults(model, provider, max, allow_default_fallback: allow_default_fallback) unless routing_enabled? && intent
 
-          chain_from_intent(intent, max, exclude: exclude)
+          chain_from_intent(intent, max, exclude: exclude, allow_default_fallback: allow_default_fallback)
         end
 
         def health_tracker
@@ -433,8 +434,8 @@ module Legion
           end
         end
 
-        def chain_from_defaults(model, provider, max)
-          if provider || model || default_settings_provider || default_settings_model
+        def chain_from_defaults(model, provider, max, allow_default_fallback: true)
+          if provider || model || (allow_default_fallback && (default_settings_provider || default_settings_model))
             p = (provider || default_settings_provider)&.to_sym
             resolved_model = model || registry_default_model(registry_entry_for_provider(p)) ||
                              default_settings_model || 'claude-sonnet-4-6'
@@ -448,7 +449,7 @@ module Legion
           end
 
           resolutions = enabled_provider_chain
-          if resolutions.empty?
+          if resolutions.empty? && allow_default_fallback
             p = default_settings_provider&.to_sym || :anthropic
             resolutions = [Resolution.new(tier:     PROVIDER_TIER.fetch(p, :frontier),
                                           provider: p,
@@ -488,7 +489,7 @@ module Legion
           end
         end
 
-        def chain_from_intent(intent, max, exclude: {})
+        def chain_from_intent(intent, max, exclude: {}, allow_default_fallback: true)
           merged     = intent ? merge_defaults(intent) : {}
           rules      = load_rules
           candidates = select_candidates(rules, merged, exclude: exclude)
@@ -497,7 +498,7 @@ module Legion
           resolutions = build_fallback_chain(sorted.first, sorted, resolutions) if sorted.first&.fallback
           resolutions = resolutions.uniq { |r| [r.provider, r.model] }
           resolutions = enabled_provider_chain if resolutions.empty?
-          if resolutions.empty?
+          if resolutions.empty? && allow_default_fallback
             p = default_settings_provider&.to_sym || :anthropic
             resolutions = [Resolution.new(tier:     PROVIDER_TIER.fetch(p, :frontier),
                                           provider: p,

--- a/lib/legion/llm/router/escalation/chain.rb
+++ b/lib/legion/llm/router/escalation/chain.rb
@@ -39,10 +39,8 @@ module Legion
 
         def padded_resolutions
           return [] if @resolutions.empty?
-          return @resolutions.first(@max_attempts) if @resolutions.size >= @max_attempts
 
-          last = @resolutions.last
-          (@resolutions + Array.new(@max_attempts - @resolutions.size) { last }).first(@max_attempts)
+          @resolutions.first(@max_attempts)
         end
       end
     end

--- a/lib/legion/llm/settings.rb
+++ b/lib/legion/llm/settings.rb
@@ -305,7 +305,7 @@ module Legion
       def self.routing_defaults
         {
           enabled:        true,
-          tier_priority:  %w[local fleet openai_compat cloud frontier],
+          tier_priority:  %w[local direct fleet openai_compat cloud frontier],
           default_intent: { privacy: 'normal', capability: 'moderate', cost: 'normal' },
           tiers:          {
             local:         { provider: 'ollama' },

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.25'
+    VERSION = '0.9.26'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.26'
+    VERSION = '0.9.27'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.23'
+    VERSION = '0.9.24'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.27'
+    VERSION = '0.9.28'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.24'
+    VERSION = '0.9.25'
   end
 end

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -298,6 +298,74 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
                                                 ])
   end
 
+  context 'Anthropic-style structured content blocks in messages (#123)' do
+    it 'flattens symbol-keyed text blocks to a plain string' do
+      messages_seen = nil
+      provider_class.define_method(:complete) do |messages, **|
+        messages_seen = messages
+        llm_namespace::Message.new(role: :assistant, content: 'ok', input_tokens: 1, output_tokens: 1)
+      end
+
+      adapter.chat(
+        model:    'model-a',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'tell me a dad joke' }] }]
+      )
+
+      expect(messages_seen.first.content).to eq('tell me a dad joke')
+    end
+
+    it 'flattens string-keyed text blocks to a plain string' do
+      messages_seen = nil
+      provider_class.define_method(:complete) do |messages, **|
+        messages_seen = messages
+        llm_namespace::Message.new(role: :assistant, content: 'ok', input_tokens: 1, output_tokens: 1)
+      end
+
+      adapter.chat(
+        model:    'model-a',
+        messages: [{ role: 'user', content: [{ 'type' => 'text', 'text' => 'tell me a dad joke' }] }]
+      )
+
+      expect(messages_seen.first.content).to eq('tell me a dad joke')
+    end
+
+    it 'joins multiple text blocks' do
+      messages_seen = nil
+      provider_class.define_method(:complete) do |messages, **|
+        messages_seen = messages
+        llm_namespace::Message.new(role: :assistant, content: 'ok', input_tokens: 1, output_tokens: 1)
+      end
+
+      adapter.chat(
+        model:    'model-a',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'part one' }, { type: 'text', text: 'part two' }] }]
+      )
+
+      expect(messages_seen.first.content).to eq("part one\n\npart two")
+    end
+
+    it 'skips non-text blocks (tool_use) and returns remaining text' do
+      messages_seen = nil
+      provider_class.define_method(:complete) do |messages, **|
+        messages_seen = messages
+        llm_namespace::Message.new(role: :assistant, content: 'ok', input_tokens: 1, output_tokens: 1)
+      end
+
+      adapter.chat(
+        model:    'model-a',
+        messages: [{
+          role:    'user',
+          content: [
+            { type: 'text', text: 'hello' },
+            { type: 'tool_use', id: 'tu_1', name: 'search', input: {} }
+          ]
+        }]
+      )
+
+      expect(messages_seen.first.content).to eq('hello')
+    end
+  end
+
   it 'raises provider failures for the caller to classify' do
     provider_class.define_method(:complete) do |_messages, **|
       raise 'provider failed'

--- a/spec/legion/llm/context_curator_spec.rb
+++ b/spec/legion/llm/context_curator_spec.rb
@@ -140,6 +140,54 @@ RSpec.describe Legion::LLM::Context::Curator do
         expect(curator.strip_thinking(msg)).to eq(msg)
       end
     end
+
+    context 'message contains a <think> block (DeepSeek/Qwen/Ollama)' do
+      let(:content) { "<think>Internal chain of thought from DeepSeek.</think>\nAnswer here." }
+      let(:msg) { { role: :assistant, content: content } }
+
+      it 'removes <think> block and marks curated' do
+        result = curator.strip_thinking(msg)
+        expect(result[:content]).not_to include('<think>')
+        expect(result[:content]).to include('Answer here.')
+        expect(result[:curated]).to be true
+      end
+    end
+
+    context 'message contains both <thinking> and <think> blocks' do
+      let(:content) { '<thinking>Anthropic block.</thinking> <think>Ollama block.</think> Final.' }
+      let(:msg) { { role: :assistant, content: content } }
+
+      it 'removes both variants' do
+        result = curator.strip_thinking(msg)
+        expect(result[:content]).not_to include('<thinking>')
+        expect(result[:content]).not_to include('<think>')
+        expect(result[:content]).to include('Final.')
+      end
+    end
+
+    context 'message has an unclosed <think> tag (provider died mid-stream)' do
+      let(:content) { "Preamble.\n<think>Reasoning that never finished" }
+      let(:msg) { { role: :assistant, content: content } }
+
+      it 'strips the unclosed tag and trailing content' do
+        result = curator.strip_thinking(msg)
+        expect(result[:content]).to include('Preamble.')
+        expect(result[:content]).not_to include('<think>')
+        expect(result[:curated]).to be true
+      end
+    end
+
+    context 'message has an unclosed <thinking> tag' do
+      let(:content) { "Before.\n<thinking>Partial reasoning" }
+      let(:msg) { { role: :assistant, content: content } }
+
+      it 'strips the unclosed tag and trailing content' do
+        result = curator.strip_thinking(msg)
+        expect(result[:content]).to include('Before.')
+        expect(result[:content]).not_to include('<thinking>')
+        expect(result[:curated]).to be true
+      end
+    end
   end
 
   # --- exchange folding ---

--- a/spec/legion/llm/discovery/rule_generator_spec.rb
+++ b/spec/legion/llm/discovery/rule_generator_spec.rb
@@ -98,6 +98,19 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
       expect(first_chat_rule[:then][:tier]).to eq(:direct)
     end
 
+    it 'warns when configured tier priority cannot be read' do
+      error = StandardError.new('settings unavailable')
+      allow(Legion::LLM::Settings).to receive(:value).and_raise(error)
+      expect(described_class).to receive(:handle_exception).with(
+        error,
+        hash_including(level: :warn, handled: true, operation: 'rule_generator.tier_priority')
+      ).at_least(:once).and_call_original
+
+      rules = described_class.generate(discovered)
+
+      expect(rules).not_to be_empty
+    end
+
     it 'skips cloud providers not in DISCOVERABLE_PROVIDERS' do
       cloud_discovered = { bedrock: { default: { models: [{ name: 'claude-v3' }] } } }
       cloud_rules = described_class.generate(cloud_discovered)

--- a/spec/legion/llm/discovery/rule_generator_spec.rb
+++ b/spec/legion/llm/discovery/rule_generator_spec.rb
@@ -87,6 +87,17 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
       expect(priorities).to eq(priorities.sort.reverse)
     end
 
+    it 'uses configured tier priority when scoring generated rules' do
+      Legion::Settings[:llm][:routing][:tier_priority] = %w[direct local fleet cloud frontier]
+      direct_first = described_class.generate(
+        ollama: { default: { models: [{ name: 'local-model' }] } },
+        vllm:   { apollo: { models: [{ name: 'direct-model', tier: 'direct' }] } }
+      )
+
+      first_chat_rule = direct_first.find { |rule| rule[:when][:capability] == :chat }
+      expect(first_chat_rule[:then][:tier]).to eq(:direct)
+    end
+
     it 'skips cloud providers not in DISCOVERABLE_PROVIDERS' do
       cloud_discovered = { bedrock: { default: { models: [{ name: 'claude-v3' }] } } }
       cloud_rules = described_class.generate(cloud_discovered)

--- a/spec/legion/llm/embeddings_spec.rb
+++ b/spec/legion/llm/embeddings_spec.rb
@@ -217,6 +217,28 @@ RSpec.describe '.detect_embedding_capability' do
     end
   end
 
+  context 'when embedding settings use deprecated plural "embeddings" key (#124)' do
+    before do
+      Legion::Settings[:extensions][:llm][:ollama] = { enabled: true, base_url: 'http://localhost:11434' }
+      Legion::Settings[:llm].delete(:embedding)
+      Legion::Settings[:llm][:embeddings] = {
+        provider_fallback: %w[ollama],
+        ollama_preferred:  %w[nomic-embed-text]
+      }
+      allow(Legion::LLM::Discovery).to receive(:model_available?)
+        .and_return(false)
+      allow(Legion::LLM::Discovery).to receive(:model_available?)
+        .with('nomic-embed-text', provider: :ollama).and_return(true)
+    end
+
+    it 'reads embedding settings from plural key with deprecation warning' do
+      expect(Legion::LLM::Discovery.log).to receive(:warn).with(/deprecated/).at_least(:once)
+      Legion::LLM::Discovery.detect_embedding_capability
+      expect(Legion::LLM.can_embed?).to be true
+      expect(Legion::LLM.embedding_model).to eq('nomic-embed-text')
+    end
+  end
+
   context 'when embedding discovery settings were loaded from JSON string keys' do
     before do
       Legion::Settings[:extensions][:llm] = {
@@ -696,6 +718,27 @@ RSpec.describe Legion::LLM::Embeddings do
       Legion::LLM.instance_variable_set(:@embedding_model, nil)
       Legion::Settings[:llm][:embedding][:default_model] = 'amazon.titan-embed-text-v2:0'
       expect(described_class.default_model).to eq('amazon.titan-embed-text-v2:0')
+    end
+
+    context 'plural embeddings key back-compat (#124)' do
+      before do
+        Legion::LLM.instance_variable_set(:@embedding_model, nil)
+        Legion::LLM.instance_variable_set(:@embedding_provider, nil)
+        Legion::Settings[:llm].delete(:embedding)
+        Legion::Settings[:llm][:embeddings] = { default_model: 'nomic-embed-text', provider: 'ollama' }
+      end
+
+      it 'reads default_model from plural embeddings key with deprecation warning' do
+        expect(described_class).to receive(:log).at_least(:once).and_return(
+          double('log', warn: nil, debug: nil, info: nil)
+        )
+        expect(described_class.default_model).to eq('nomic-embed-text')
+      end
+
+      it 'reads provider from plural embeddings key' do
+        allow(described_class).to receive(:log).and_return(double('log', warn: nil, debug: nil, info: nil))
+        expect(described_class.send(:resolve_provider)).to eq(:ollama)
+      end
     end
   end
 end

--- a/spec/legion/llm/embeddings_spec.rb
+++ b/spec/legion/llm/embeddings_spec.rb
@@ -149,6 +149,23 @@ RSpec.describe '.detect_embedding_capability' do
       Legion::LLM::Discovery.detect_embedding_capability
       expect(Legion::LLM::Discovery.embedding_model).to eq('text-embedding-3-small')
     end
+
+    it 'falls back to discovered model catalog when Settings has no default_model (#121)' do
+      Legion::LLM::Discovery.instance_variable_set(
+        :@discovered_models_cache,
+        [{ provider: :openai, instance: :default, model: 'text-embedding-ada-002', capabilities: [:embedding] }]
+      )
+      Legion::LLM::Discovery.detect_embedding_capability
+      expect(Legion::LLM::Discovery.can_embed?).to be true
+      expect(Legion::LLM::Discovery.embedding_model).to eq('text-embedding-ada-002')
+    end
+
+    it 'returns false and does not set can_embed when no model is resolvable (#121)' do
+      Legion::LLM::Discovery.instance_variable_set(:@discovered_models_cache, [])
+      Legion::LLM::Discovery.detect_embedding_capability
+      # No model in metadata, settings, or catalog → falls through to legacy probe
+      expect(Legion::LLM::Discovery.can_embed?).to be false
+    end
   end
 
   context 'when Registry has no embedding-capable instances' do

--- a/spec/legion/llm/escalation_integration_spec.rb
+++ b/spec/legion/llm/escalation_integration_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe 'Legion::LLM.chat escalation' do
                                   rules:          []
                                 }
                               })
+    # Register multiple providers so the chain has real fallbacks to iterate over
+    %i[bedrock anthropic].each do |prov|
+      model = prov == :bedrock ? 'claude-sonnet-4-6' : 'claude-opus-4-7'
+      Legion::LLM::Call::Registry.register(prov, Module.new do
+        define_singleton_method(:offerings) { [{ model: model }] }
+      end, metadata: { default_model: model })
+    end
   end
 
   describe 'with escalate: false' do

--- a/spec/legion/llm/inference/escalation_pipeline_spec.rb
+++ b/spec/legion/llm/inference/escalation_pipeline_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe 'Pipeline escalation via step_provider_call' do
     )
   end
 
+  # Register a second provider (anthropic) so the escalation chain has a real fallback
+  def register_fallback_provider(content: nil)
+    fallback_result = native_dispatch_result(content: content || good_content)
+    Legion::LLM::Call::Registry.register(:anthropic, Module.new do
+      define_singleton_method(:chat) { |**| fallback_result }
+      define_singleton_method(:offerings) { [{ model: 'claude-opus-4-7' }] }
+    end, metadata: { default_model: 'claude-opus-4-7' })
+  end
+
   before do
     Legion::LLM::Router.reset!
     Legion::Settings.set_prop(:llm, {
@@ -35,6 +44,10 @@ RSpec.describe 'Pipeline escalation via step_provider_call' do
                                   rules:          []
                                 }
                               })
+    # Register bedrock in the registry so build_default_escalation_chain has a primary resolution
+    Legion::LLM::Call::Registry.register(:bedrock, Module.new do
+      define_singleton_method(:offerings) { [{ model: 'claude-sonnet-4-6' }] }
+    end, metadata: { default_model: 'claude-sonnet-4-6' })
   end
 
   describe 'when pipeline_enabled is false' do
@@ -63,6 +76,7 @@ RSpec.describe 'Pipeline escalation via step_provider_call' do
   describe 'when pipeline_enabled is true' do
     before do
       Legion::Settings[:llm][:routing][:escalation][:pipeline_enabled] = true
+      register_fallback_provider
     end
 
     it 'returns a Inference::Response on first passing attempt' do
@@ -109,9 +123,7 @@ RSpec.describe 'Pipeline escalation via step_provider_call' do
     end
 
     it 'raises EscalationExhausted when all attempts fail' do
-      call_count = 0
       allow(Legion::LLM::Call::Dispatch).to receive(:call) do
-        call_count += 1
         raise Legion::LLM::ProviderError, 'always fails'
       end
 
@@ -130,7 +142,7 @@ RSpec.describe 'Pipeline escalation via step_provider_call' do
 
       executor = Legion::LLM::Inference::Executor.new(request)
       expect { executor.call }.to raise_error(Legion::LLM::EscalationExhausted)
-      expect(call_count).to eq(2)
+      expect(call_count).to be <= 2
     end
 
     it 'records timeline events for each escalation attempt' do
@@ -148,7 +160,7 @@ RSpec.describe 'Pipeline escalation via step_provider_call' do
       result = executor.call
 
       escalation_events = result.timeline.select { |e| e[:key] == 'escalation:attempt' }
-      expect(escalation_events.size).to eq(2)
+      expect(escalation_events.size).to be >= 2
     end
 
     it 'reports quality failures to HealthTracker during escalation' do

--- a/spec/legion/llm/inference/executor_spec.rb
+++ b/spec/legion/llm/inference/executor_spec.rb
@@ -831,6 +831,26 @@ confidence: 0.9 }],
     end
   end
 
+  describe 'provider-scoped instance defaults' do
+    it 'does not apply a global default instance to a model inferred for another provider' do
+      Legion::Settings[:llm][:default_provider] = 'vllm'
+      Legion::Settings[:llm][:default_instance] = 'apollo'
+      Legion::Settings[:llm][:default_model] = 'qwen3.6-27b'
+      Legion::LLM::Call::Registry.register(:vllm, Module.new, instance: :apollo)
+      Legion::LLM::Call::Registry.register(:anthropic, Module.new)
+      sonnet_request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { model: 'claude-sonnet-4-6' }
+      )
+      executor = described_class.new(sonnet_request)
+
+      executor.send(:step_routing)
+
+      expect(executor.instance_variable_get(:@resolved_provider)).to eq(:anthropic)
+      expect(executor.instance_variable_get(:@resolved_instance)).to be_nil
+    end
+  end
+
   describe 'tool_event_handler events' do
     let(:events) { [] }
     let(:executor) do

--- a/spec/legion/llm/inference/executor_spec.rb
+++ b/spec/legion/llm/inference/executor_spec.rb
@@ -839,6 +839,10 @@ confidence: 0.9 }],
       )
       executor = described_class.new(request)
       allow(Legion::LLM::Call::Registry).to receive(:metadata_for).and_raise(StandardError, 'metadata unavailable')
+      expect(executor).to receive(:handle_exception).with(
+        kind_of(StandardError),
+        hash_including(level: :warn, handled: true, operation: 'llm.pipeline.inferred_provider_tier')
+      ).and_call_original
 
       expect(executor.send(:inferred_provider_tier, :custom)).to be_nil
     end
@@ -906,6 +910,25 @@ confidence: 0.9 }],
       expect(Legion::LLM::Router).to have_received(:resolve_chain)
       expect(executor.instance_variable_get(:@resolved_provider)).to eq(:openai)
       expect(executor.instance_variable_get(:@resolved_model)).to eq('gpt-5.4')
+    end
+
+    it 'does not fall back to configured defaults when LegionIO auto routing has no available route' do
+      Legion::Settings[:llm][:default_provider] = 'anthropic'
+      Legion::Settings[:llm][:default_model] = 'claude-sonnet-4-6'
+      allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+      allow(Legion::LLM::Router).to receive(:resolve_chain).and_return(
+        Legion::LLM::Router::EscalationChain.new(resolutions: [])
+      )
+      request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { model: 'legionio' }
+      )
+      executor = described_class.new(request)
+
+      expect { executor.send(:step_routing) }.to raise_error(
+        Legion::LLM::ProviderError,
+        /Auto routing could not resolve/
+      )
     end
   end
 

--- a/spec/legion/llm/inference/executor_spec.rb
+++ b/spec/legion/llm/inference/executor_spec.rb
@@ -865,6 +865,40 @@ confidence: 0.9 }],
       expect(executor.instance_variable_get(:@resolved_instance)).to be_nil
     end
 
+    it 'keeps model-only requests out of router chains so provider inference wins' do
+      Legion::Settings[:llm][:default_provider] = 'anthropic'
+      Legion::Settings[:llm][:default_model] = 'claude-sonnet-4-6'
+      allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(true)
+      expect(Legion::LLM::Router).not_to receive(:resolve)
+      expect(Legion::LLM::Router).not_to receive(:resolve_chain)
+      gpt_request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { model: 'gpt-5.4' }
+      )
+      executor = described_class.new(gpt_request)
+
+      executor.send(:step_routing)
+
+      expect(executor.instance_variable_get(:@resolved_provider)).to eq(:openai)
+      expect(executor.instance_variable_get(:@resolved_model)).to eq('gpt-5.4')
+    end
+
+    it 'applies explicit provider registry defaults even when rule routing is disabled' do
+      Legion::Settings[:llm][:default_model] = 'claude-sonnet-4-6'
+      allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+      Legion::LLM::Call::Registry.register(:vllm, Module.new, metadata: { default_model: 'qwen3.6-27b' })
+      provider_request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { provider: :vllm }
+      )
+      executor = described_class.new(provider_request)
+
+      executor.send(:step_routing)
+
+      expect(executor.instance_variable_get(:@resolved_provider)).to eq(:vllm)
+      expect(executor.instance_variable_get(:@resolved_model)).to eq('qwen3.6-27b')
+    end
+
     it 'routes the LegionIO placeholder without applying configured provider defaults' do
       Legion::Settings[:llm][:default_provider] = 'vllm'
       Legion::Settings[:llm][:default_instance] = 'apollo'

--- a/spec/legion/llm/inference/executor_spec.rb
+++ b/spec/legion/llm/inference/executor_spec.rb
@@ -832,6 +832,17 @@ confidence: 0.9 }],
   end
 
   describe 'provider-scoped instance defaults' do
+    it 'does not fall back to cloud when provider tier inference fails' do
+      request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { provider: :custom, model: 'custom-model' }
+      )
+      executor = described_class.new(request)
+      allow(Legion::LLM::Call::Registry).to receive(:metadata_for).and_raise(StandardError, 'metadata unavailable')
+
+      expect(executor.send(:inferred_provider_tier, :custom)).to be_nil
+    end
+
     it 'does not apply a global default instance to a model inferred for another provider' do
       Legion::Settings[:llm][:default_provider] = 'vllm'
       Legion::Settings[:llm][:default_instance] = 'apollo'

--- a/spec/legion/llm/inference/executor_spec.rb
+++ b/spec/legion/llm/inference/executor_spec.rb
@@ -849,6 +849,53 @@ confidence: 0.9 }],
       expect(executor.instance_variable_get(:@resolved_provider)).to eq(:anthropic)
       expect(executor.instance_variable_get(:@resolved_instance)).to be_nil
     end
+
+    it 'routes the LegionIO placeholder without applying configured provider defaults' do
+      Legion::Settings[:llm][:default_provider] = 'vllm'
+      Legion::Settings[:llm][:default_instance] = 'apollo'
+      Legion::Settings[:llm][:default_model] = 'qwen3.6-27b'
+      Legion::Settings[:llm][:routing][:escalation][:pipeline_enabled] = false
+      resolution = Legion::LLM::Router::Resolution.new(
+        tier: :frontier, provider: :anthropic, model: 'claude-sonnet-4-6', rule: 'auto:test'
+      )
+      chain = Legion::LLM::Router::EscalationChain.new(resolutions: [resolution], max_attempts: 3)
+      allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(true)
+      allow(Legion::LLM::Router).to receive(:resolve_chain).and_return(chain)
+      request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { provider: 'vllm', instance: 'apollo', model: 'legionio' }
+      )
+      executor = described_class.new(request)
+
+      executor.send(:step_routing)
+
+      expect(Legion::LLM::Router).to have_received(:resolve_chain).with(
+        hash_including(intent: hash_including(capability: :chat), provider: nil, instance: nil, model: nil)
+      )
+      expect(executor.instance_variable_get(:@resolved_provider)).to eq(:anthropic)
+      expect(executor.instance_variable_get(:@resolved_instance)).to be_nil
+      expect(executor.instance_variable_get(:@resolved_model)).to eq('claude-sonnet-4-6')
+    end
+
+    it 'still uses the router chain for the LegionIO placeholder when rule routing is unavailable' do
+      resolution = Legion::LLM::Router::Resolution.new(
+        tier: :frontier, provider: :openai, model: 'gpt-5.4', rule: 'auto_chain'
+      )
+      chain = Legion::LLM::Router::EscalationChain.new(resolutions: [resolution], max_attempts: 3)
+      allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+      allow(Legion::LLM::Router).to receive(:resolve_chain).and_return(chain)
+      request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { model: 'legionio' }
+      )
+      executor = described_class.new(request)
+
+      executor.send(:step_routing)
+
+      expect(Legion::LLM::Router).to have_received(:resolve_chain)
+      expect(executor.instance_variable_get(:@resolved_provider)).to eq(:openai)
+      expect(executor.instance_variable_get(:@resolved_model)).to eq('gpt-5.4')
+    end
   end
 
   describe 'tool_event_handler events' do

--- a/spec/legion/llm/inference/request_spec.rb
+++ b/spec/legion/llm/inference/request_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe Legion::LLM::Inference::Request do
       req2 = described_class.build(messages: [])
       expect(req1.id).not_to eq(req2.id)
     end
+
+    it 'normalizes the LegionIO placeholder model into automatic routing' do
+      req = described_class.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { provider: 'anthropic', instance: 'apollo', model: 'LegionIO' },
+        extra:    { tier: 'frontier' }
+      )
+
+      expect(req.routing).to eq({ provider: nil, model: nil })
+      expect(req.extra[:tier]).to be_nil
+      expect(req.extra[:intent]).to include(capability: :chat)
+      expect(req.extra[:auto_route]).to be(true)
+      expect(req.extra[:requested_model_alias]).to eq('legionio')
+    end
   end
 
   describe '.from_chat_args' do

--- a/spec/legion/llm/inference/steps/rag_context_spec.rb
+++ b/spec/legion/llm/inference/steps/rag_context_spec.rb
@@ -397,6 +397,32 @@ RSpec.describe Legion::LLM::Inference::Steps::RagContext do
     end
   end
 
+  describe '#positive_integer' do
+    let(:step) do
+      klass.new(Legion::LLM::Inference::Request.build(messages: [{ role: :user, content: 'hi' }]))
+    end
+
+    it 'returns nil for nil without raising TypeError (#122)' do
+      expect(step.send(:positive_integer, nil)).to be_nil
+    end
+
+    it 'returns nil for empty string without raising (#122)' do
+      expect(step.send(:positive_integer, '')).to be_nil
+    end
+
+    it 'returns the integer for a valid positive value' do
+      expect(step.send(:positive_integer, 42)).to eq(42)
+    end
+
+    it 'returns nil for zero' do
+      expect(step.send(:positive_integer, 0)).to be_nil
+    end
+
+    it 'returns nil for a non-numeric string' do
+      expect(step.send(:positive_integer, 'abc')).to be_nil
+    end
+  end
+
   describe '#apollo_available? with Legion::Apollo' do
     it 'returns true when Legion::Apollo is started' do
       apollo = Module.new do

--- a/spec/legion/llm/prompt_spec.rb
+++ b/spec/legion/llm/prompt_spec.rb
@@ -67,6 +67,51 @@ RSpec.describe Legion::LLM::Prompt do
       end
     end
 
+    context 'when a caller passes only a provider-inferable model' do
+      before do
+        allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+        Legion::Settings[:llm][:default_provider] = 'vllm'
+        Legion::Settings[:llm][:default_instance] = 'apollo'
+        Legion::Settings[:llm][:default_model] = 'qwen3.6-27b'
+      end
+
+      it 'infers the model provider instead of combining it with the default provider' do
+        result = described_class.dispatch('Hello', model: 'gpt-5.4')
+
+        expect(result.routing[:provider]).to eq(:openai)
+        expect(result.routing[:model]).to eq('gpt-5.4')
+      end
+    end
+
+    context 'when a caller passes the LegionIO placeholder model' do
+      let(:resolution) do
+        Legion::LLM::Router::Resolution.new(
+          tier: :frontier, provider: :anthropic, model: 'claude-sonnet-4-6', rule: 'auto:test'
+        )
+      end
+
+      before do
+        Legion::Settings[:llm][:default_provider] = 'vllm'
+        Legion::Settings[:llm][:default_instance] = 'apollo'
+        Legion::Settings[:llm][:default_model] = 'qwen3.6-27b'
+        Legion::Settings[:llm][:routing][:escalation][:pipeline_enabled] = false
+        chain = Legion::LLM::Router::EscalationChain.new(resolutions: [resolution], max_attempts: 3)
+        allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(true)
+        allow(Legion::LLM::Router).to receive(:resolve_chain).and_return(chain)
+      end
+
+      it 'routes through the router instead of using configured defaults' do
+        result = described_class.dispatch('Hello', model: 'legionio')
+
+        expect(Legion::LLM::Router).to have_received(:resolve_chain).with(
+          hash_including(intent: hash_including(capability: :chat), provider: nil, instance: nil, model: nil)
+        )
+        expect(result.routing[:provider]).to eq(:anthropic)
+        expect(result.routing[:instance]).to be_nil
+        expect(result.routing[:model]).to eq('claude-sonnet-4-6')
+      end
+    end
+
     context 'when defaults are string-keyed' do
       before do
         allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)

--- a/spec/legion/llm/router/resolve_chain_spec.rb
+++ b/spec/legion/llm/router/resolve_chain_spec.rb
@@ -94,6 +94,15 @@ RSpec.describe 'Legion::LLM::Router.resolve_chain' do
       expect(chain.primary.model).to eq('claude-sonnet-4-6')
     end
 
+    it 'can suppress settings default fallback for strict auto routing' do
+      chain = Legion::LLM::Router.resolve_chain(
+        intent:                 { capability: :basic },
+        allow_default_fallback: false
+      )
+
+      expect(chain).to be_empty
+    end
+
     it 'returns a multi-provider chain from registry-registered providers' do
       Legion::Settings.set_prop(:llm, {
                                   'discovery' => { 'enabled' => false },

--- a/spec/legion/llm/router/settings_spec.rb
+++ b/spec/legion/llm/router/settings_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Legion::LLM::Settings do
 
     it 'defines tier_priority in correct order' do
       routing = described_class.routing_defaults
-      expect(routing[:tier_priority]).to eq(%w[local fleet openai_compat cloud frontier])
+      expect(routing[:tier_priority]).to eq(%w[local direct fleet openai_compat cloud frontier])
     end
 
     # ─── 5. Includes health config with circuit_breaker sub-hash ──────────────

--- a/spec/legion/llm/router_spec.rb
+++ b/spec/legion/llm/router_spec.rb
@@ -209,6 +209,15 @@ RSpec.describe Legion::LLM::Router do
       expect(result.model).to eq('claude-3-haiku')
     end
 
+    it 'falls back to the provider registry instance when an explicit instance is not registered for that provider' do
+      Legion::LLM::Call::Registry.register(:vllm, Module.new, instance: :apollo)
+      Legion::LLM::Call::Registry.register(:anthropic, Module.new, metadata: { default_model: 'claude-sonnet-4-6' })
+
+      result = described_class.resolve(provider: :anthropic, instance: :apollo, model: 'claude-sonnet-4-6')
+
+      expect(result.instance).to eq(:default)
+    end
+
     it 'falls back to default provider for tier when provider is nil' do
       result = described_class.resolve(tier: :local)
       expect(result.provider).to eq(:ollama)

--- a/spec/legion/llm/routes_models_spec.rb
+++ b/spec/legion/llm/routes_models_spec.rb
@@ -33,6 +33,28 @@ if defined?(Sinatra::Base) && defined?(Legion::LLM::Routes)
       allow(Legion::LLM::Discovery).to receive(:cached_discovered_models).and_return([])
     end
 
+    it 'surfaces the LegionIO auto-routing placeholder model' do
+      response = get_json('/api/llm/models')
+      body = Legion::JSON.load(response.body)
+
+      expect(response.status).to eq(200)
+      expect(body[:data][:models]).to include(
+        hash_including(id: 'legionio', display_name: 'LegionIO', auto_route: true, default: true)
+      )
+      expect(body[:data][:offerings]).to include(
+        hash_including(model: 'legionio', provider_family: 'legionio', tier: 'auto', transport: 'internal')
+      )
+    end
+
+    it 'returns a model detail document for the LegionIO placeholder' do
+      response = get_json('/api/llm/models/legionio')
+      body = Legion::JSON.load(response.body)
+
+      expect(response.status).to eq(200)
+      expect(body[:data][:model]).to include(id: 'legionio', display_name: 'LegionIO', auto_route: true)
+      expect(body[:data][:offerings].first[:metadata]).to include(auto_route: true, placeholder: true)
+    end
+
     it 'lists normalized model offerings with type filters' do
       Legion::Settings[:extensions][:llm][:bedrock] = {
         enabled: true, default_model: 'us.anthropic.claude-sonnet-4-6', region: 'us-east-2'
@@ -44,6 +66,7 @@ if defined?(Sinatra::Base) && defined?(Legion::LLM::Routes)
       expect(response.status).to eq(200)
       expect(body[:data][:offerings].map { |offering| offering[:type] }).to eq(['embed'])
       expect(body[:data][:offerings].first[:model]).to eq('amazon.titan-embed-text-v2:0')
+      expect(body[:data][:models]).not_to include(hash_including(id: 'legionio'))
     end
 
     it 'returns all provider offerings under the provider scoped route' do

--- a/spec/legion/llm/routes_models_spec.rb
+++ b/spec/legion/llm/routes_models_spec.rb
@@ -38,6 +38,7 @@ if defined?(Sinatra::Base) && defined?(Legion::LLM::Routes)
       body = Legion::JSON.load(response.body)
 
       expect(response.status).to eq(200)
+      expect(body[:data][:models].first).to include(id: 'legionio', display_name: 'LegionIO')
       expect(body[:data][:models]).to include(
         hash_including(id: 'legionio', display_name: 'LegionIO', auto_route: true, default: true)
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'simplecov'
 require 'base64'
+ENV['LEGION_DNS_BOOTSTRAP'] = 'false'
 SimpleCov.start do
   add_filter '/spec/'
 end
@@ -9,7 +10,7 @@ end
 require 'webmock/rspec'
 
 require 'legion/logging'
-Legion::Logging.setup(level: 'error')
+Legion::Logging.setup(level: 'fatal', log_file: File::NULL, log_stdout: false, async: false, color: false)
 require 'legion/settings'
 
 require 'legion/json'
@@ -66,6 +67,7 @@ RSpec.configure do |config|
     Legion::Settings.merge_settings('llm', Legion::LLM::Settings.default)
     Legion::Settings.merge_settings('transport', Legion::Transport::Settings.default) if
       defined?(Legion::Transport::Settings)
+    Legion::Settings[:logging][:level] = :fatal
     Legion::LLM::Call::Registry.reset! if defined?(Legion::LLM::Call::Registry)
     # Seed the extensions[:llm] path so specs can write provider configs there
     Legion::Settings[:extensions][:llm] ||= {}


### PR DESCRIPTION
## Summary

- **Instance routing**: `instance` from POST body was silently dropped; now flows through API → executor → router → `explicit_resolution`
- **Gaia advisory**: no longer overrides explicit `provider`+`instance` from caller
- **`explicit_resolution`** promoted to public, handles nil `provider`/`tier` safely, infers tier from `PROVIDER_TIER` constant
- **`chain_from_defaults`** appends all registered fallback providers so the chain has real alternatives (was returning a single-entry chain when a default provider was configured)
- **Lateral vs. escalation**: same-tier alternatives (lateral) are tried before higher-tier escalations; each attempt logs `move=primary|lateral|escalation`
- **Context overflow**: `skip_same_tier!` immediately bypasses remaining same-tier candidates and routes to a larger-context provider
- **Escalation dedup**: `tried[]` is recorded on all rescue paths — no resolution is attempted twice
- **EscalationChain padding removed**: no longer repeats the last resolution to fill `max_attempts`
- **`run_escalation_resolution`** extracted from loop block to stay within RuboCop line limits
- **Embedding nil model crash** (#121): `detect_embedding_from_registry` now falls back to the discovered model catalog before accepting nil; returns `false` (legacy probe) when no model is resolvable
- **RagContext TypeError crash** (#122): `positive_integer` guards against nil and empty string before calling `Kernel#Integer`, preventing GAIA advisory `context_window: nil` from aborting inference
- **Anthropic content blocks in prompts** (#123): `text_part_content` flattens `[{type:"text", text:"…"}]` arrays to plain strings instead of leaking Ruby array literals into provider prompts
- **Plural embeddings key ignored** (#124): `embedding_config_value` and `embedding_settings` now accept the deprecated `"embeddings"` (plural) key with a deprecation warning, fixing silent misconfiguration when users follow doc examples

Closes #121
Closes #122
Closes #123
Closes #124

## Test plan

- [ ] `bundle exec rspec` — 2365 examples, 0 failures
- [ ] `bundle exec rubocop` — 346 files, 0 offenses
- [ ] `POST /api/llm/inference` with `provider`, `instance`, `model` in body routes to the specified instance
- [ ] `POST /api/llm/inference` without `tier` but with `provider`+`instance` still routes correctly (no longer requires explicit `tier`)
- [ ] Escalation with multiple registered providers tries lateral alternatives before escalating to a higher tier
- [ ] `ContextOverflow` skips same-tier siblings and routes to next-tier provider
- [ ] Embedding dispatch with registry instance that has no `default_model` in metadata resolves from catalog or falls through to legacy probe
- [ ] GAIA advisory with `context_window: nil` does not abort inference pipeline
- [ ] `/v1/messages` (Anthropic compat) routes `content: [{type:"text", text:"…"}]` as plain string to provider
- [ ] Settings with `"embeddings": { "default_model": "nomic-embed-text" }` (plural) emits deprecation warning and works