### PR TITLE
Route LLM requests by required capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Legion LLM Changelog
 
+## [0.9.29] - 2026-05-16
+
+### Added
+- Routing: generated discovery rules now expose `:tools` capability rules for tool-capable models and normalize provider aliases such as `function_calling`/`functions`.
+
+### Changed
+- Routing: automatic routing honors top-level `llm.tier_order` before routing-specific tier priority settings.
+- Routing: stream requests with injected native tools now require both `streaming` and `tools` model capabilities before selecting a target.
+
+### Fixed
+- Router: required model capabilities filter out non-tool-capable candidates instead of selecting a local model that later rejects tool payloads.
+- Executor: streaming provider calls now use the escalation chain, so provider errors like "does not support tools" can move to the next routed model.
+- Executor: synthetic routing requirements no longer make model-only or explicit-provider requests bypass provider inference or registry defaults.
+
 ## [0.9.28] - 2026-05-15
 
 ### Added

--- a/lib/legion/llm/api/native/tiers.rb
+++ b/lib/legion/llm/api/native/tiers.rb
@@ -160,8 +160,12 @@ module Legion
           end
 
           def self.tier_priority
+            return Legion::LLM::Router.tier_priority if defined?(Legion::LLM::Router)
+
             routing_config = Legion::LLM::Settings.value(:routing) || {}
-            Array(routing_config[:tier_priority] || %w[local fleet openai_compat cloud frontier])
+            top_level = Legion::LLM::Settings.value(:tier_order, default: nil)
+            Array(top_level || routing_config[:tier_order] || routing_config[:tier_priority] ||
+                  %w[local direct fleet openai_compat cloud frontier])
           end
 
           def self.privacy_mode?

--- a/lib/legion/llm/discovery/rule_generator.rb
+++ b/lib/legion/llm/discovery/rule_generator.rb
@@ -27,6 +27,14 @@ module Legion
         }.freeze
 
         DEFAULT_TIER_PRIORITY = %i[local direct fleet openai_compat cloud frontier].freeze
+        CAPABILITY_ALIASES = {
+          function_calling: :tools,
+          functions:        :tools,
+          tool:             :tools,
+          tool_use:         :tools,
+          stream:           :streaming,
+          stream_chat:      :streaming
+        }.freeze
 
         module_function
 
@@ -52,7 +60,10 @@ module Legion
                 capability = embedding_model?(model_data) ? :embed : :chat
                 priority = tier_weight(model_tier) - order
                 rules << build_rule(provider, instance_id, model_data, capability, model_tier, priority)
-                rules << build_rule(provider, instance_id, model_data, :stream, model_tier, priority) if capability == :chat
+                if capability == :chat
+                  rules << build_rule(provider, instance_id, model_data, :stream, model_tier, priority) if supports_streaming?(model_data)
+                  rules << build_rule(provider, instance_id, model_data, :tools, model_tier, priority) if supports_tools?(model_data)
+                end
                 order += 1
               end
             end
@@ -125,9 +136,37 @@ module Legion
           return nil unless model_data.is_a?(Hash)
 
           caps = model_data[:capabilities] || model_data['capabilities']
-          return caps if caps.is_a?(Array) && caps.any?
+          normalized = normalize_capabilities(caps)
+          return normalized if normalized.any?
 
           nil
+        end
+
+        def supports_streaming?(model_data)
+          capabilities = extract_capabilities(model_data)
+          return true if capabilities.nil?
+
+          capabilities.include?(:streaming)
+        end
+
+        def supports_tools?(model_data)
+          capabilities = extract_capabilities(model_data)
+          return false if capabilities.nil?
+
+          capabilities.include?(:tools)
+        end
+
+        def normalize_capabilities(capabilities)
+          Array(capabilities).compact.each_with_object([]) do |capability, normalized|
+            next unless capability.respond_to?(:to_s)
+
+            capability_sym = capability.to_s.downcase.strip.to_sym
+            next if capability_sym.to_s.empty?
+
+            normalized << capability_sym
+            alias_sym = CAPABILITY_ALIASES[capability_sym]
+            normalized << alias_sym if alias_sym
+          end.uniq
         end
 
         def extract_field(model_data, field)
@@ -145,7 +184,9 @@ module Legion
         end
 
         def tier_priority
-          configured = Legion::LLM::Settings.value(:routing, :tier_priority, default: DEFAULT_TIER_PRIORITY)
+          configured = Legion::LLM::Settings.value(:tier_order, default: nil)
+          configured = Legion::LLM::Settings.value(:routing, :tier_order, default: nil) if blank_array?(configured)
+          configured = Legion::LLM::Settings.value(:routing, :tier_priority, default: DEFAULT_TIER_PRIORITY) if blank_array?(configured)
           normalized = Array(configured).filter_map do |tier|
             tier.to_sym if tier.respond_to?(:to_sym)
           end
@@ -154,6 +195,10 @@ module Legion
         rescue StandardError => e
           handle_exception(e, level: :warn, handled: true, operation: 'rule_generator.tier_priority')
           DEFAULT_TIER_PRIORITY
+        end
+
+        def blank_array?(value)
+          Array(value).empty?
         end
 
         def extension_providers

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -376,6 +376,7 @@ module Legion
 
         def routing_request_state
           routing_explicit = @request.extra[:routing_explicit]
+          request_intent = @request.extra[:intent]
           instance = @request.routing[:instance] || @request.routing[:instance_id] || @request.routing[:provider_instance]
           tier = @request.extra[:tier]
           {
@@ -385,13 +386,73 @@ module Legion
             offering_id:       @request.routing[:offering_id] || @request.routing[:id],
             offering_metadata: normalize_offering_metadata(@request.routing[:offering_metadata] ||
                                                            @request.routing[:offering]),
-            intent:            @request.extra[:intent],
+            intent:            routing_intent_for_request(request_intent),
+            intent_explicit:   routing_intent_present?(request_intent),
             tier:              tier,
             auto_route:        @request.extra[:auto_route],
             provider_explicit: routing_field_explicit?(routing_explicit, :provider, @request.routing[:provider]),
             instance_explicit: routing_field_explicit?(routing_explicit, :instance, instance),
             tier_explicit:     routing_field_explicit?(routing_explicit, :tier, tier)
           }
+        end
+
+        def routing_intent_present?(intent)
+          intent.is_a?(Hash) && intent.any?
+        end
+
+        def routing_intent_for_request(intent)
+          normalized = if intent.is_a?(Hash)
+                         intent.transform_keys { |key| key.respond_to?(:to_sym) ? key.to_sym : key }
+                       else
+                         {}
+                       end
+          required = normalize_required_capabilities(
+            normalized.delete(:required_capabilities) || normalized.delete(:requires)
+          )
+
+          if @request.stream == true
+            normalized[:capability] = :stream if stream_routable_capability?(normalized[:capability])
+            required << :streaming
+          end
+
+          required << :tools if native_tools_requested_for_routing?
+          normalized[:required_capabilities] = required.uniq if required.any?
+          normalized
+        end
+
+        def stream_routable_capability?(capability)
+          capability.nil? || %i[chat completion stream].include?(capability.to_s.downcase.to_sym)
+        end
+
+        def native_tools_requested_for_routing?
+          Array(@request.tools).any? ||
+            requested_deferred_tool_names.any? ||
+            @triggered_tools.any? ||
+            Tools::Special.pinned_definitions.any?
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: 'llm.pipeline.routing_tools_required')
+          false
+        end
+
+        def normalize_required_capabilities(capabilities)
+          aliases = {
+            function_calling: :tools,
+            functions:        :tools,
+            tool:             :tools,
+            tool_use:         :tools,
+            stream:           :streaming,
+            stream_chat:      :streaming
+          }
+          Array(capabilities).compact.each_with_object([]) do |capability, normalized|
+            next unless capability.respond_to?(:to_s)
+
+            capability_sym = capability.to_s.downcase.strip.to_sym
+            next if capability_sym.to_s.empty?
+
+            normalized << capability_sym
+            alias_sym = aliases[capability_sym]
+            normalized << alias_sym if alias_sym
+          end.uniq
         end
 
         def apply_proactive_tier_assignment(state)
@@ -416,7 +477,7 @@ module Legion
 
           explicit_route = state[:provider_explicit] || state[:instance_explicit] || state[:tier_explicit]
           auto_route = state[:auto_route] == true
-          intent_route = state[:intent] && Router.routing_enabled?
+          intent_route = state[:intent_explicit] && state[:intent] && Router.routing_enabled?
           return state unless explicit_route || auto_route || intent_route
 
           resolution = routing_resolution_for(state)
@@ -426,7 +487,7 @@ module Legion
         end
 
         def routing_resolution_for(state)
-          if state[:auto_route] == true || (state[:intent] && pipeline_escalation_enabled?)
+          if state[:auto_route] == true || (state[:intent_explicit] && state[:intent] && pipeline_escalation_enabled?)
             @escalation_chain = Router.resolve_chain(
               intent:                 state[:intent],
               tier:                   state[:tier],
@@ -527,13 +588,14 @@ module Legion
           end
         end
 
-        def run_provider_call_with_escalation
+        def run_provider_call_with_escalation(stream_block: nil)
           @escalation_chain ||= build_default_escalation_chain
           chain = @escalation_chain
           threshold = pipeline_escalation_quality_threshold
           quality_check = @request.extra[:quality_check]
           succeeded = false
           tried = []
+          @last_escalation_error = nil
           log.debug "[llm][executor] action=escalation.enter chain_size=#{chain.size} threshold=#{threshold}"
 
           primary_tier = @escalation_chain.primary&.tier
@@ -541,10 +603,12 @@ module Legion
           chain.each do |resolution|
             next if tried.any? { |t| t[:provider] == resolution.provider && t[:instance] == resolution.instance && t[:model] == resolution.model }
 
-            succeeded = run_escalation_resolution(resolution, threshold, quality_check, tried, primary_tier)
+            succeeded = run_escalation_resolution(resolution, threshold, quality_check, tried, primary_tier,
+                                                  stream_block: stream_block)
             break if succeeded
           end
           return if succeeded
+          raise @last_escalation_error if chain.size <= 1 && @last_escalation_error
 
           emit_error_audit(
             EscalationExhausted.new("All #{@escalation_history.size} attempts failed"),
@@ -553,7 +617,7 @@ module Legion
           raise EscalationExhausted, "All #{@escalation_history.size} escalation attempts failed"
         end
 
-        def run_escalation_resolution(resolution, threshold, quality_check, tried, primary_tier)
+        def run_escalation_resolution(resolution, threshold, quality_check, tried, primary_tier, stream_block: nil)
           move_type = if tried.empty?
                         :primary
                       elsif resolution.tier == primary_tier
@@ -570,7 +634,7 @@ module Legion
           @resolved_tier = resolution.tier
           @resolved_offering_id = resolution.offering_id
           @resolved_offering_metadata = resolution.offering_metadata
-          succeeded = attempt_escalation(resolution, threshold, quality_check, start_time)
+          succeeded = attempt_escalation(resolution, threshold, quality_check, start_time, stream_block: stream_block)
           tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model } unless succeeded
           succeeded
         rescue Legion::LLM::AuthError, Legion::LLM::PrivacyModeError => e
@@ -605,14 +669,19 @@ module Legion
           false
         end
 
-        def attempt_escalation(resolution, threshold, quality_check, start_time)
+        def attempt_escalation(resolution, threshold, quality_check, start_time, stream_block: nil)
           @current_escalation_context = {
             attempt:      @escalation_history.size + 1,
             max_attempts: @escalation_chain&.max_attempts
           }.compact
-          execute_provider_request
+          if stream_block
+            execute_provider_request_stream(&stream_block)
+            result = Quality::Checker::QualityResult.new(passed: true, failures: [])
+          else
+            execute_provider_request
+            result = Quality::Checker.check(@raw_response, quality_threshold: threshold, quality_check: quality_check)
+          end
           duration_ms = ((Time.now - start_time) * 1000).round
-          result = Quality::Checker.check(@raw_response, quality_threshold: threshold, quality_check: quality_check)
           outcome = result.passed ? :success : :quality_failure
           @timeline.record(
             category: :provider, key: 'escalation:attempt', direction: :internal,
@@ -649,6 +718,7 @@ module Legion
         end
 
         def record_escalation_failure(err, resolution, start_time, outcome:, operation:, handled: false)
+          @last_escalation_error = err
           duration_ms = ((Time.now - start_time) * 1000).round
           handle_exception(err, level: :warn, handled: handled, operation: operation,
                                provider: resolution.provider, model: resolution.model, duration_ms: duration_ms)
@@ -689,7 +759,7 @@ module Legion
         end
 
         def build_fallback_resolutions(exclude_provider: nil, exclude_instance: nil, primary_tier: nil)
-          tier_rank = Router::TIER_RANK
+          tier_rank = Router.tier_rank
           primary_rank = primary_tier ? (tier_rank[primary_tier.to_sym] || 99) : 99
 
           candidates = Call::Registry.all_instances.filter_map do |entry|
@@ -1168,10 +1238,15 @@ module Legion
 
         private :async_post_enabled?
 
-        def step_provider_call_stream(&)
+        def step_provider_call_stream(&block)
+          if pipeline_escalation_enabled?
+            run_provider_call_with_escalation(stream_block: block)
+            return
+          end
+
           providers_tried = []
           begin
-            execute_provider_request_stream(&)
+            execute_provider_request_stream(&block)
           rescue Legion::LLM::AuthError, Faraday::UnauthorizedError, Faraday::ForbiddenError => e
             try_fallback_or_raise(e, providers_tried, operation: 'provider_call_stream.auth',
                                                       reason: 'auth_failed', error_class: Legion::LLM::AuthError)

--- a/lib/legion/llm/inventory.rb
+++ b/lib/legion/llm/inventory.rb
@@ -35,6 +35,15 @@ module Legion
         chat:      %i[chat completion tools json_schema]
       }.freeze
 
+      CAPABILITY_ALIASES = {
+        function_calling: :tools,
+        functions:        :tools,
+        tool:             :tools,
+        tool_use:         :tools,
+        stream:           :streaming,
+        stream_chat:      :streaming
+      }.freeze
+
       class << self
         def offerings(filters = {})
           log.debug "[llm][inventory] action=offerings.enter filters=#{filters.keys}"
@@ -216,7 +225,16 @@ module Legion
 
         def normalize_capabilities(capabilities, type)
           raw = capabilities || DEFAULT_CAPABILITIES.fetch(type, DEFAULT_CAPABILITIES[:inference])
-          Array(raw).map(&:to_s).uniq.sort
+          Array(raw).compact.each_with_object([]) do |capability, normalized|
+            next unless capability.respond_to?(:to_s)
+
+            capability_sym = capability.to_s.downcase.strip.to_sym
+            next if capability_sym.to_s.empty?
+
+            normalized << capability_sym
+            alias_sym = CAPABILITY_ALIASES[capability_sym]
+            normalized << alias_sym if alias_sym
+          end.uniq.map(&:to_s).sort
         end
 
         def normalize_type(value)

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -19,6 +19,14 @@ module Legion
       PROVIDER_ORDER = %i[ollama vllm bedrock azure gemini anthropic openai].freeze
       TIER_EXTERNAL = Set[:cloud, :frontier, :openai_compat].freeze
       TIER_RANK = { local: 0, direct: 1, fleet: 2, openai_compat: 3, cloud: 4, frontier: 5 }.freeze
+      CAPABILITY_ALIASES = {
+        function_calling: :tools,
+        functions:        :tools,
+        tool:             :tools,
+        tool_use:         :tools,
+        stream:           :streaming,
+        stream_chat:      :streaming
+      }.freeze
 
       OLLAMA_MODEL_PATTERN = %r{[:/]}
 
@@ -118,6 +126,22 @@ module Legion
           @health_tracker = nil
           @auto_rules = []
           @auto_rules_populated = false
+        end
+
+        def tier_priority
+          configured = Legion::LLM::Settings.value(:tier_order, default: nil)
+          configured = routing_settings[:tier_order] if configured.nil? || Array(configured).empty?
+          configured = routing_settings[:tier_priority] if configured.nil? || Array(configured).empty?
+          normalized = Array(configured).filter_map { |tier| tier.to_sym if tier.respond_to?(:to_sym) }
+          normalized = TIER_RANK.keys if normalized.empty?
+          (normalized + TIER_RANK.keys).uniq
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: 'router.tier_priority')
+          TIER_RANK.keys
+        end
+
+        def tier_rank
+          tier_priority.each_with_index.to_h
         end
 
         # Check whether a tier can be used right now.
@@ -227,16 +251,19 @@ module Legion
           # 3. Filter by schedule
           scheduled = matched.select(&:within_schedule?)
 
-          # 4. Reject rules excluded by active constraints
-          unconstrained = scheduled.reject { |r| excluded_by_constraint?(r, constraints) }
+          # 4. Reject rules that cannot satisfy required model capabilities
+          capable = scheduled.select { |r| satisfies_required_capabilities?(r, intent) }
 
-          # 4.5 Reject Ollama rules where model is not pulled or doesn't fit
+          # 5. Reject rules excluded by active constraints
+          unconstrained = capable.reject { |r| excluded_by_constraint?(r, constraints) }
+
+          # 5.5 Reject Ollama rules where model is not pulled or doesn't fit
           discovered = unconstrained.reject { |r| excluded_by_discovery?(r) }
 
-          # 4.55 Reject local-tier rules where model exceeds available memory
+          # 5.55 Reject local-tier rules where model exceeds available memory
           memory_checked = discovered.reject { |r| excluded_by_memory?(r) }
 
-          # 4.6 Reject rules matching caller-provided exclude list
+          # 5.6 Reject rules matching caller-provided exclude list
           normalized_exclude = exclude.is_a?(Hash) ? exclude : {}
           not_excluded = if normalized_exclude.empty?
                            memory_checked
@@ -244,15 +271,46 @@ module Legion
                            memory_checked.reject { |r| excluded_by_caller?(r, normalized_exclude) }
                          end
 
-          # 4.7 Reject rules for models denied by health tracker
+          # 5.7 Reject rules for models denied by health tracker
           not_denied = not_excluded.reject { |r| excluded_by_denial?(r) }
 
-          # 5. Filter by tier availability
+          # 6. Filter by tier availability
           final = not_denied.select { |r| tier_available?(r.target[:tier] || r.target['tier']) }
 
           log.debug("Router: #{final.size} candidates after filtering (started with #{rules.size})")
 
           final
+        end
+
+        def satisfies_required_capabilities?(rule, intent)
+          required = required_capabilities(intent)
+          return true if required.empty?
+
+          rule_capabilities = normalize_capabilities(rule.target[:model_capabilities] || rule.target['model_capabilities'] ||
+                                                     rule.target[:capabilities] || rule.target['capabilities'])
+          return false if rule_capabilities.empty?
+
+          required.all? { |capability| rule_capabilities.include?(capability) }
+        end
+
+        def required_capabilities(intent)
+          return [] unless intent.is_a?(Hash)
+
+          normalized = intent.transform_keys { |key| key.respond_to?(:to_sym) ? key.to_sym : key }
+          normalize_capabilities(normalized[:required_capabilities] || normalized[:requires])
+        end
+
+        def normalize_capabilities(capabilities)
+          Array(capabilities).compact.each_with_object([]) do |capability, normalized|
+            next unless capability.respond_to?(:to_s)
+
+            capability_sym = capability.to_s.downcase.strip.to_sym
+            next if capability_sym.to_s.empty?
+
+            normalized << capability_sym
+            alias_sym = CAPABILITY_ALIASES[capability_sym]
+            normalized << alias_sym if alias_sym
+          end.uniq
         end
 
         def excluded_by_constraint?(rule, constraints)
@@ -474,8 +532,15 @@ module Legion
             seen[pname] ||= entry
           end
 
-          # Build resolutions in PROVIDER_ORDER
-          PROVIDER_ORDER.filter_map do |pname|
+          # Build resolutions ordered by configured tier priority, preserving provider preference inside a tier.
+          provider_index = PROVIDER_ORDER.each_with_index.to_h
+          sorted_entries = seen.values.sort_by do |entry|
+            tier = registry_tier(entry[:provider], entry[:metadata])
+            [tier_rank.fetch(tier, 99), provider_index.fetch(entry[:provider], PROVIDER_ORDER.size)]
+          end
+
+          sorted_entries.filter_map do |entry|
+            pname = entry[:provider]
             entry = seen[pname]
             next unless entry
 

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.28'
+    VERSION = '0.9.29'
   end
 end

--- a/spec/legion/llm/discovery/rule_generator_spec.rb
+++ b/spec/legion/llm/discovery/rule_generator_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
       default: {
         models: [
           { 'name' => 'llama3.1:8b', 'size' => 4_700_000_000,
-            'capabilities' => %i[completion tools], 'context_length' => 131_072,
+            'capabilities' => %i[completion streaming tools], 'context_length' => 131_072,
             'parameter_count' => 8_000_000_000 },
           { 'name' => 'qwen2.5:32b', 'size' => 20_000_000_000,
-            'capabilities' => %i[completion vision tools thinking], 'context_length' => 262_144 },
+            'capabilities' => %i[completion streaming vision tools thinking], 'context_length' => 262_144 },
           { 'name' => 'nomic-embed-text', 'size' => 274_000_000,
             'capabilities' => [:embedding], 'context_length' => 8_192 }
         ]
@@ -56,15 +56,24 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
       expect(embed_rules.first[:when]).to eq({ capability: :embed })
     end
 
-    it 'generates chat + stream rules for inference models' do
+    it 'generates chat, stream, and tools rules for capable inference models' do
       llama_rules = rules.select { |r| r[:name].include?('llama3.1:8b') }
       capabilities = llama_rules.map { |r| r[:when][:capability] }
-      expect(capabilities).to contain_exactly(:chat, :stream)
+      expect(capabilities).to contain_exactly(:chat, :stream, :tools)
     end
 
     it 'does not generate stream rules for embedding models' do
       embed_stream = rules.select { |r| r[:name].include?('nomic-embed-text') && r[:when][:capability] == :stream }
       expect(embed_stream).to be_empty
+    end
+
+    it 'does not generate stream rules when discovered capabilities exclude streaming' do
+      no_stream_rules = described_class.generate(
+        ollama: { local: { models: [{ name: 'no-stream-model', capabilities: %i[completion tools] }] } }
+      )
+
+      capabilities = no_stream_rules.map { |r| r[:when][:capability] }
+      expect(capabilities).to contain_exactly(:chat, :tools)
     end
 
     it 'assigns :local tier for ollama models' do
@@ -89,6 +98,17 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
 
     it 'uses configured tier priority when scoring generated rules' do
       Legion::Settings[:llm][:routing][:tier_priority] = %w[direct local fleet cloud frontier]
+      direct_first = described_class.generate(
+        ollama: { default: { models: [{ name: 'local-model' }] } },
+        vllm:   { apollo: { models: [{ name: 'direct-model', tier: 'direct' }] } }
+      )
+
+      first_chat_rule = direct_first.find { |rule| rule[:when][:capability] == :chat }
+      expect(first_chat_rule[:then][:tier]).to eq(:direct)
+    end
+
+    it 'uses top-level tier_order when scoring generated rules' do
+      Legion::Settings[:llm][:tier_order] = %w[direct local cloud frontier]
       direct_first = described_class.generate(
         ollama: { default: { models: [{ name: 'local-model' }] } },
         vllm:   { apollo: { models: [{ name: 'direct-model', tier: 'direct' }] } }
@@ -217,6 +237,19 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
         expect(rule[:then][:model_capabilities]).to eq(%i[completion vision tools thinking])
       end
 
+      it 'normalizes function_calling capability aliases to tools' do
+        aliased = described_class.build_rule(
+          :vllm,
+          :apollo,
+          { name: 'qwen-tools', capabilities: %i[completion streaming function_calling] },
+          :chat,
+          :direct,
+          100
+        )
+
+        expect(aliased[:then][:model_capabilities]).to include(:function_calling, :tools)
+      end
+
       it 'includes context_length in the target' do
         expect(rule[:then][:context_length]).to eq(262_144)
       end
@@ -236,7 +269,7 @@ RSpec.describe Legion::LLM::Discovery::RuleGenerator do
 
     it 'includes model_capabilities from ollama enrichment' do
       llama_rule = rules.find { |r| r[:name].include?('llama3.1:8b') && r[:when][:capability] == :chat }
-      expect(llama_rule[:then][:model_capabilities]).to eq(%i[completion tools])
+      expect(llama_rule[:then][:model_capabilities]).to eq(%i[completion streaming tools])
     end
 
     it 'includes context_length from ollama enrichment' do

--- a/spec/legion/llm/inference/escalation_pipeline_spec.rb
+++ b/spec/legion/llm/inference/escalation_pipeline_spec.rb
@@ -122,6 +122,35 @@ RSpec.describe 'Pipeline escalation via step_provider_call' do
       expect(call_count).to eq(2)
     end
 
+    it 'retries streaming provider errors through the escalation chain' do
+      streaming_request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'hello' }],
+        routing:  { provider: :bedrock, model: 'claude-sonnet-4-6' },
+        stream:   true
+      )
+
+      chunk = Struct.new(:content).new(good_content)
+      call_count = 0
+      allow(Legion::LLM::Call::Dispatch).to receive(:call) do |provider:, **, &block|
+        call_count += 1
+        raise Legion::LLM::ProviderError, 'does not support tools' if provider == :bedrock
+
+        block&.call(chunk)
+        native_dispatch_result(content: good_content)
+      end
+
+      streamed_chunks = []
+      result = Legion::LLM::Inference::Executor.new(streaming_request).call_stream do |stream_chunk|
+        streamed_chunks << stream_chunk.content
+      end
+
+      expect(result).to be_a(Legion::LLM::Inference::Response)
+      expect(result.message[:content]).to eq(good_content)
+      expect(streamed_chunks).to eq([good_content])
+      expect(call_count).to eq(2)
+      expect(result.routing[:provider]).to eq(:anthropic)
+    end
+
     it 'raises EscalationExhausted when all attempts fail' do
       allow(Legion::LLM::Call::Dispatch).to receive(:call) do
         raise Legion::LLM::ProviderError, 'always fails'

--- a/spec/legion/llm/inference/executor_routing_capabilities_spec.rb
+++ b/spec/legion/llm/inference/executor_routing_capabilities_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::LLM::Inference::Executor do
+  describe 'routing capability requirements' do
+    it 'routes LegionIO streaming requests only to streaming tool-capable targets' do
+      allow(Legion::LLM::Tools::Special).to receive(:pinned_definitions).and_return([
+                                                                                      instance_double(
+                                                                                        Legion::LLM::Types::ToolDefinition,
+                                                                                        name: :ruby
+                                                                                      )
+                                                                                    ])
+
+      request = Legion::LLM::Inference::Request.build(
+        messages: [{ role: :user, content: 'test' }],
+        routing:  { model: 'legionio' },
+        stream:   true
+      )
+
+      state = described_class.new(request).send(:routing_request_state)
+
+      expect(state[:intent][:capability]).to eq(:stream)
+      expect(state[:intent][:required_capabilities]).to contain_exactly(:streaming, :tools)
+    end
+  end
+end

--- a/spec/legion/llm/router_spec.rb
+++ b/spec/legion/llm/router_spec.rb
@@ -150,6 +150,41 @@ RSpec.describe Legion::LLM::Router do
       # basic-fallback cost_multiplier 1.0 -> cost_bonus = 0 -> effective = 10
       expect(result.rule).to eq('basic-local')
     end
+
+    it 'requires declared model capabilities when the intent asks for them' do
+      rules_with_capabilities = [
+        {
+          name:     'stream-local-no-tools',
+          when:     { capability: 'stream' },
+          then:     {
+            tier:               'local',
+            provider:           'ollama',
+            model:              'hf.co/unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL',
+            model_capabilities: %i[completion streaming]
+          },
+          priority: 200
+        },
+        {
+          name:     'stream-direct-tools',
+          when:     { capability: 'stream' },
+          then:     {
+            tier:               'direct',
+            provider:           'vllm',
+            instance:           'apollo',
+            model:              'qwen3.6-27b',
+            model_capabilities: %i[completion streaming tools]
+          },
+          priority: 100
+        }
+      ]
+      configure_routing(rules: rules_with_capabilities)
+
+      result = described_class.resolve(intent: { capability: 'stream', required_capabilities: %i[tools streaming] })
+
+      expect(result.rule).to eq('stream-direct-tools')
+      expect(result.provider).to eq(:vllm)
+      expect(result.instance).to eq(:apollo)
+    end
   end
 
   # ─── 5. Fills missing intent dimensions from defaults ─────────────────────────


### PR DESCRIPTION
## Summary
- Adds required capability filtering to router candidates so tool/stream requests do not select models that lack `tools` or `streaming` metadata.
- Honors top-level `llm.tier_order` in rule scoring, tier APIs, provider chains, and escalation sorting.
- Routes `model: legionio` streaming requests with injected native tools through `streaming` + `tools` requirements, and sends stream provider errors through the escalation chain.
- Keeps synthetic routing requirements from turning model-only or explicit-provider requests into router-chain requests.

## Verification
- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- `bundle exec rubocop -A`