### PR TITLE
Fix extract_token missing input_tokens in streaming response.completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.9.34] - 2026-05-22
+
+### Fixed
+- API: `extract_token` now correctly reads `:input_tokens` / `:output_tokens` hash keys from `pipeline_response.tokens`, fixing `input_tokens: 0` in streaming `response.completed` events (caused Codex CLI `stream disconnected before completion` error)
+
 ## [0.9.33] - 2026-05-22
 
 ### Added

--- a/lib/legion/llm/api/openai/responses.rb
+++ b/lib/legion/llm/api/openai/responses.rb
@@ -257,9 +257,14 @@ module Legion
 
           def self.extract_token(tokens, key)
             return 0 if tokens.nil?
-            return (tokens[key] || tokens[key.to_s] || 0).to_i if tokens.is_a?(Hash)
 
             method_name = { input: :input_tokens, output: :output_tokens }[key]
+
+            if tokens.is_a?(Hash)
+              return (tokens[method_name] || tokens[method_name.to_s] ||
+                      tokens[key] || tokens[key.to_s] || 0).to_i
+            end
+
             return tokens.public_send(method_name).to_i if method_name && tokens.respond_to?(method_name)
 
             0

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.33'
+    VERSION = '0.9.34'
   end
 end


### PR DESCRIPTION
The hash returned by pipeline_response.tokens uses :input_tokens / :output_tokens keys, but extract_token was only checking :input / :output when tokens is a Hash, always falling through to 0. Prioritise the full method-name keys so streaming response.completed events report accurate token counts instead of input_tokens: 0.

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
