### PR TITLE
Preserve gateway usage in streaming adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.9.36] - 2026-05-22
+
+### Fixed
+- Providers: `LexLLMAdapter` now preserves streamed token usage from the upstream `llm-gateway.uhg.com` Responses API payload added in LegionIO/legion-llm#130, including gateway-shaped `usage`, `raw[:data]`, and `raw[:response][:usage]` token fields, so LegionIO `response.completed.usage.input_tokens` no longer collapses to `0`
+
 ## [0.9.35] - 2026-05-22
 
 ### Fixed

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -336,10 +336,11 @@ module Legion
         end
 
         def accumulate_stream_usage(accumulator, chunk)
-          return unless chunk.respond_to?(:input_tokens)
+          usage = usage_hash(chunk)
+          return unless token_usage_signal?(chunk, usage)
 
           accumulator[:model] = chunk.model_id if chunk.respond_to?(:model_id)
-          accumulator[:usage] = usage_hash(chunk)
+          accumulator[:usage] = merge_usage_hash(accumulator[:usage], usage)
           accumulator[:raw] = chunk.raw if chunk.respond_to?(:raw)
         end
 
@@ -392,11 +393,87 @@ module Legion
 
         def usage_hash(response)
           {
-            input_tokens:       response.input_tokens.to_i,
-            output_tokens:      response.output_tokens.to_i,
-            cache_read_tokens:  response.cached_tokens.to_i,
-            cache_write_tokens: response.cache_creation_tokens.to_i
+            input_tokens:       extract_token_metric(response, :input_tokens, :prompt_tokens),
+            output_tokens:      extract_token_metric(response, :output_tokens, :completion_tokens),
+            cache_read_tokens:  extract_token_metric(response, :cache_read_tokens, :cached_tokens),
+            cache_write_tokens: extract_token_metric(response, :cache_write_tokens, :cache_creation_tokens)
           }
+        end
+
+        def token_usage_signal?(response, usage)
+          usage.values.any?(&:positive?) ||
+            response.respond_to?(:usage) ||
+            response.respond_to?(:raw) ||
+            response.respond_to?(:input_tokens) ||
+            response.respond_to?(:output_tokens)
+        end
+
+        def merge_usage_hash(existing, incoming)
+          current = existing.is_a?(Hash) ? existing : {}
+          latest = incoming.is_a?(Hash) ? incoming : {}
+
+          {
+            input_tokens:       [current[:input_tokens].to_i, latest[:input_tokens].to_i].max,
+            output_tokens:      [current[:output_tokens].to_i, latest[:output_tokens].to_i].max,
+            cache_read_tokens:  [current[:cache_read_tokens].to_i, latest[:cache_read_tokens].to_i].max,
+            cache_write_tokens: [current[:cache_write_tokens].to_i, latest[:cache_write_tokens].to_i].max
+          }
+        end
+
+        def extract_token_metric(response, canonical_key, legacy_key = nil)
+          values = token_metric_candidates(response, canonical_key, legacy_key)
+          positive = values.find(&:positive?)
+          positive || values.first || 0
+        end
+
+        def token_metric_candidates(response, canonical_key, legacy_key = nil)
+          keys = [canonical_key, legacy_key].compact
+          token_metric_sources(response).flat_map do |source|
+            keys.filter_map { |key| extract_metric_value(source, key) }
+          end
+        end
+
+        def token_metric_sources(response)
+          sources = [response]
+          sources << response.usage if response.respond_to?(:usage)
+          sources << response.raw if response.respond_to?(:raw)
+
+          sources.compact.flat_map { |source| expand_token_metric_source(source) }.compact.uniq
+        end
+
+        def expand_token_metric_source(source, depth = 0)
+          return [] if source.nil?
+          return [source] unless source.respond_to?(:key?) && depth < 3
+
+          nested = [source]
+          nested << hash_value(source, :usage)
+          nested << hash_value(source, :data)
+          nested << hash_value(source, :response)
+          nested.compact.flat_map { |entry| [entry, *expand_token_metric_source(entry, depth + 1)] }
+        end
+
+        def extract_metric_value(source, key)
+          if source.respond_to?(key)
+            value = source.public_send(key)
+            return value.to_i unless value.nil?
+          end
+
+          return nil unless source.respond_to?(:key?)
+
+          value = hash_value(source, key)
+          value.to_i unless value.nil?
+        rescue StandardError => e
+          log.debug "[llm][adapter] action=extract_metric_value key=#{key} class=#{source.class} error=#{e.class}: #{e.message}"
+          nil
+        end
+
+        def hash_value(hash, key)
+          return hash[key] if hash.key?(key)
+
+          string_key = key.to_s
+          return hash[string_key] if hash.key?(string_key)
+
+          nil
         end
 
         def stream_thinking_hash(accumulator)

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -461,7 +461,7 @@ module Legion
           return nil unless source.respond_to?(:key?)
 
           value = hash_value(source, key)
-          value.to_i unless value.nil?
+          value&.to_i
         rescue StandardError => e
           log.debug "[llm][adapter] action=extract_metric_value key=#{key} class=#{source.class} error=#{e.class}: #{e.message}"
           nil

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.35'
+    VERSION = '0.9.36'
   end
 end

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -272,12 +272,12 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens:         0,
-      output_tokens:        5,
-      cached_tokens:        0,
+      input_tokens:          0,
+      output_tokens:         5,
+      cached_tokens:         0,
       cache_creation_tokens: 0,
-      usage:                nil,
-      raw:                  { data: { input_tokens: 9, output_tokens: 5 } }
+      usage:                 nil,
+      raw:                   { data: { input_tokens: 9, output_tokens: 5 } }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(
@@ -294,11 +294,11 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens:         0,
-      output_tokens:        0,
-      cached_tokens:        0,
+      input_tokens:          0,
+      output_tokens:         0,
+      cached_tokens:         0,
       cache_creation_tokens: 0,
-      usage:                {
+      usage:                 {
         input_tokens:          8,
         input_tokens_details:  { cached_tokens: 0 },
         output_tokens:         6,
@@ -321,11 +321,11 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens:         0,
-      output_tokens:        0,
-      cached_tokens:        0,
+      input_tokens:          0,
+      output_tokens:         0,
+      cached_tokens:         0,
       cache_creation_tokens: 0,
-      usage:                { prompt_tokens: 11, completion_tokens: 4 }
+      usage:                 { prompt_tokens: 11, completion_tokens: 4 }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -266,6 +266,93 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
     expect(result[:thinking]).to eq(content: 'internal reasoning', enabled: true)
   end
 
+  it 'extracts token usage from raw data when direct token readers are zero' do
+    response_class = Struct.new(
+      :input_tokens, :output_tokens, :cached_tokens, :cache_creation_tokens, :usage, :raw,
+      keyword_init: true
+    )
+    response = response_class.new(
+      input_tokens:         0,
+      output_tokens:        5,
+      cached_tokens:        0,
+      cache_creation_tokens: 0,
+      usage:                nil,
+      raw:                  { data: { input_tokens: 9, output_tokens: 5 } }
+    )
+
+    expect(adapter.send(:usage_hash, response)).to eq(
+      input_tokens:       9,
+      output_tokens:      5,
+      cache_read_tokens:  0,
+      cache_write_tokens: 0
+    )
+  end
+
+  it 'extracts token usage from gateway response usage hashes' do
+    response_class = Struct.new(
+      :input_tokens, :output_tokens, :cached_tokens, :cache_creation_tokens, :usage,
+      keyword_init: true
+    )
+    response = response_class.new(
+      input_tokens:         0,
+      output_tokens:        0,
+      cached_tokens:        0,
+      cache_creation_tokens: 0,
+      usage:                {
+        input_tokens:           8,
+        input_tokens_details:   { cached_tokens: 0 },
+        output_tokens:          6,
+        output_tokens_details:  { reasoning_tokens: 0 },
+        total_tokens:           14
+      }
+    )
+
+    expect(adapter.send(:usage_hash, response)).to eq(
+      input_tokens:       8,
+      output_tokens:      6,
+      cache_read_tokens:  0,
+      cache_write_tokens: 0
+    )
+  end
+
+  it 'extracts token usage from prompt/completion token usage hashes' do
+    response_class = Struct.new(
+      :input_tokens, :output_tokens, :cached_tokens, :cache_creation_tokens, :usage,
+      keyword_init: true
+    )
+    response = response_class.new(
+      input_tokens:         0,
+      output_tokens:        0,
+      cached_tokens:        0,
+      cache_creation_tokens: 0,
+      usage:                { prompt_tokens: 11, completion_tokens: 4 }
+    )
+
+    expect(adapter.send(:usage_hash, response)).to eq(
+      input_tokens:       11,
+      output_tokens:      4,
+      cache_read_tokens:  0,
+      cache_write_tokens: 0
+    )
+  end
+
+  it 'merges stream usage from raw fallback data even when chunks omit input_tokens readers' do
+    chunk_class = Struct.new(:content, :model_id, :usage, :raw, keyword_init: true)
+    accumulator = adapter.send(:build_stream_accumulator)
+    chunk = chunk_class.new(
+      content:  'hi',
+      model_id: 'model-a',
+      usage:    nil,
+      raw:      { response: { usage: { input_tokens: 8, output_tokens: 2 } } }
+    )
+
+    adapter.send(:accumulate_stream_usage, accumulator, chunk)
+
+    expect(accumulator[:usage]).to include(input_tokens: 8, output_tokens: 2)
+    expect(accumulator[:model]).to eq('model-a')
+    expect(accumulator[:raw]).to eq(response: { usage: { input_tokens: 8, output_tokens: 2 } })
+  end
+
   it 'estimates token count for non-hash message inputs' do
     result = adapter.count_tokens(model: 'model-a', messages: ['hello world'])
 

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -272,18 +272,18 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens: 0,
-      output_tokens: 5,
-      cached_tokens: 0,
+      input_tokens:         0,
+      output_tokens:        5,
+      cached_tokens:        0,
       cache_creation_tokens: 0,
-      usage: nil,
-      raw: { data: { input_tokens: 9, output_tokens: 5 } }
+      usage:                nil,
+      raw:                  { data: { input_tokens: 9, output_tokens: 5 } }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(
-      input_tokens: 9,
-      output_tokens: 5,
-      cache_read_tokens: 0,
+      input_tokens:       9,
+      output_tokens:      5,
+      cache_read_tokens:  0,
       cache_write_tokens: 0
     )
   end
@@ -294,23 +294,23 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens: 0,
-      output_tokens: 0,
-      cached_tokens: 0,
+      input_tokens:         0,
+      output_tokens:        0,
+      cached_tokens:        0,
       cache_creation_tokens: 0,
-      usage: {
-        input_tokens: 8,
-        input_tokens_details: { cached_tokens: 0 },
-        output_tokens: 6,
+      usage:                {
+        input_tokens:          8,
+        input_tokens_details:  { cached_tokens: 0 },
+        output_tokens:         6,
         output_tokens_details: { reasoning_tokens: 0 },
-        total_tokens: 14
+        total_tokens:          14
       }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(
-      input_tokens: 8,
-      output_tokens: 6,
-      cache_read_tokens: 0,
+      input_tokens:       8,
+      output_tokens:      6,
+      cache_read_tokens:  0,
       cache_write_tokens: 0
     )
   end
@@ -321,17 +321,17 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens: 0,
-      output_tokens: 0,
-      cached_tokens: 0,
+      input_tokens:         0,
+      output_tokens:        0,
+      cached_tokens:        0,
       cache_creation_tokens: 0,
-      usage: { prompt_tokens: 11, completion_tokens: 4 }
+      usage:                { prompt_tokens: 11, completion_tokens: 4 }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(
-      input_tokens: 11,
-      output_tokens: 4,
-      cache_read_tokens: 0,
+      input_tokens:       11,
+      output_tokens:      4,
+      cache_read_tokens:  0,
       cache_write_tokens: 0
     )
   end
@@ -340,10 +340,10 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
     chunk_class = Struct.new(:content, :model_id, :usage, :raw, keyword_init: true)
     accumulator = adapter.send(:build_stream_accumulator)
     chunk = chunk_class.new(
-      content: 'hi',
+      content:  'hi',
       model_id: 'model-a',
-      usage: nil,
-      raw: { response: { usage: { input_tokens: 8, output_tokens: 2 } } }
+      usage:    nil,
+      raw:      { response: { usage: { input_tokens: 8, output_tokens: 2 } } }
     )
 
     adapter.send(:accumulate_stream_usage, accumulator, chunk)

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -272,18 +272,18 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens:         0,
-      output_tokens:        5,
-      cached_tokens:        0,
+      input_tokens: 0,
+      output_tokens: 5,
+      cached_tokens: 0,
       cache_creation_tokens: 0,
-      usage:                nil,
-      raw:                  { data: { input_tokens: 9, output_tokens: 5 } }
+      usage: nil,
+      raw: { data: { input_tokens: 9, output_tokens: 5 } }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(
-      input_tokens:       9,
-      output_tokens:      5,
-      cache_read_tokens:  0,
+      input_tokens: 9,
+      output_tokens: 5,
+      cache_read_tokens: 0,
       cache_write_tokens: 0
     )
   end
@@ -294,23 +294,23 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens:         0,
-      output_tokens:        0,
-      cached_tokens:        0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cached_tokens: 0,
       cache_creation_tokens: 0,
-      usage:                {
-        input_tokens:           8,
-        input_tokens_details:   { cached_tokens: 0 },
-        output_tokens:          6,
-        output_tokens_details:  { reasoning_tokens: 0 },
-        total_tokens:           14
+      usage: {
+        input_tokens: 8,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens: 6,
+        output_tokens_details: { reasoning_tokens: 0 },
+        total_tokens: 14
       }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(
-      input_tokens:       8,
-      output_tokens:      6,
-      cache_read_tokens:  0,
+      input_tokens: 8,
+      output_tokens: 6,
+      cache_read_tokens: 0,
       cache_write_tokens: 0
     )
   end
@@ -321,17 +321,17 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
       keyword_init: true
     )
     response = response_class.new(
-      input_tokens:         0,
-      output_tokens:        0,
-      cached_tokens:        0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cached_tokens: 0,
       cache_creation_tokens: 0,
-      usage:                { prompt_tokens: 11, completion_tokens: 4 }
+      usage: { prompt_tokens: 11, completion_tokens: 4 }
     )
 
     expect(adapter.send(:usage_hash, response)).to eq(
-      input_tokens:       11,
-      output_tokens:      4,
-      cache_read_tokens:  0,
+      input_tokens: 11,
+      output_tokens: 4,
+      cache_read_tokens: 0,
       cache_write_tokens: 0
     )
   end
@@ -340,10 +340,10 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
     chunk_class = Struct.new(:content, :model_id, :usage, :raw, keyword_init: true)
     accumulator = adapter.send(:build_stream_accumulator)
     chunk = chunk_class.new(
-      content:  'hi',
+      content: 'hi',
       model_id: 'model-a',
-      usage:    nil,
-      raw:      { response: { usage: { input_tokens: 8, output_tokens: 2 } } }
+      usage: nil,
+      raw: { response: { usage: { input_tokens: 8, output_tokens: 2 } } }
     )
 
     adapter.send(:accumulate_stream_usage, accumulator, chunk)


### PR DESCRIPTION
## Summary
- Follow-up to LegionIO/legion-llm#130: preserve upstream llm-gateway Responses API token usage after the SSE envelope fix
- Extract streamed usage from direct readers, gateway-style `usage`, `raw[:data]`, and `raw[:response][:usage]` payloads
- Bump `legion-llm` to 0.9.36 and document the adapter fix in the changelog

## Validation
- Validated `gateway/v1/responses` returns `response.completed.response.usage.input_tokens=8` for `gpt-5.4` / `say hello`
- Ran adapter harness under bundled Ruby 3.4.8 confirming gateway usage, `raw[:data]`, and `raw[:response][:usage]` all produce nonzero token counts
- `ruby -c lib/legion/llm/call/lex_llm_adapter.rb`

## Note
- Could not run focused RSpec locally because the workspace bundle does not currently have the `rspec` executable installed.