### PR TITLE
Dispatch Responses API calls upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.9.37] - 2026-05-22
+
+### Changed
+- API: OpenAI Responses requests now dispatch to upstream `/v1/responses` through a native `:responses` provider capability instead of adapting Responses input through Chat Completions `stream_chat`, preserving upstream Responses streaming usage from `response.completed.response.usage`
+
 ## [0.9.36] - 2026-05-22
 
 ### Fixed

--- a/lib/legion/llm/api/openai/responses.rb
+++ b/lib/legion/llm/api/openai/responses.rb
@@ -76,13 +76,13 @@ module Legion
                         'X-Accel-Buffering' => 'no'
 
                 stream do |out|
-                  Responses.stream_response(out, executor, request_id: request_id, model: model)
+                  Responses.stream_response(out, executor, request_id: request_id, model: model, upstream_body: body)
                 rescue StandardError => e
                   handle_exception(e, level: :error, handled: false, operation: 'llm.api.openai.responses.stream', request_id: request_id)
                   out << "event: error\ndata: #{Legion::JSON.dump({ type: 'server_error', message: e.message })}\n\n"
                 end
               else
-                pipeline_response = executor.call
+                pipeline_response = executor.call_responses(body: body, stream: false)
                 response_body = Responses.format_response(pipeline_response, request_id: request_id, model: model)
 
                 log.info("[llm][api][openai][responses] action=complete request_id=#{request_id} model=#{response_body[:model]}")
@@ -179,7 +179,7 @@ module Legion
             }
           end
 
-          def self.stream_response(out, executor, request_id:, model:) # rubocop:disable Metrics/MethodLength
+          def self.stream_response(out, executor, request_id:, model:, upstream_body: nil) # rubocop:disable Metrics/MethodLength
             created_at = Time.now.to_i
             seq = 0
             in_progress_response = { id: request_id, object: 'response', created_at: created_at,
@@ -218,7 +218,7 @@ module Legion
 
             full_text = +''
 
-            pipeline_response = executor.call_stream do |chunk|
+            pipeline_response = call_streaming_executor(executor, upstream_body: upstream_body) do |chunk|
               text = chunk.respond_to?(:content) ? chunk.content.to_s : chunk.to_s
               next if text.empty?
 
@@ -280,6 +280,14 @@ module Legion
                              })
 
             log.info("[llm][api][openai][responses] action=stream_complete request_id=#{request_id} model=#{resolved_model}")
+          end
+
+          def self.call_streaming_executor(executor, upstream_body: nil, &block)
+            if upstream_body && executor.respond_to?(:call_responses)
+              executor.call_responses(body: upstream_body, stream: true, &block)
+            else
+              executor.call_stream(&block)
+            end
           end
 
           def self.sse_event(name, payload)

--- a/lib/legion/llm/api/openai/responses.rb
+++ b/lib/legion/llm/api/openai/responses.rb
@@ -282,11 +282,11 @@ module Legion
             log.info("[llm][api][openai][responses] action=stream_complete request_id=#{request_id} model=#{resolved_model}")
           end
 
-          def self.call_streaming_executor(executor, upstream_body: nil, &block)
+          def self.call_streaming_executor(executor, upstream_body: nil, &)
             if upstream_body && executor.respond_to?(:call_responses)
-              executor.call_responses(body: upstream_body, stream: true, &block)
+              executor.call_responses(body: upstream_body, stream: true, &)
             else
-              executor.call_stream(&block)
+              executor.call_stream(&)
             end
           end
 

--- a/lib/legion/llm/call/dispatch.rb
+++ b/lib/legion/llm/call/dispatch.rb
@@ -168,6 +168,7 @@ module Legion
         CAPABILITY_METHODS = {
           chat:         :chat,
           stream:       :stream,
+          responses:    :responses,
           embed:        :embed,
           image:        :image,
           count_tokens: :count_tokens

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -59,18 +59,18 @@ module Legion
           end
         end
 
-        def responses(model:, body:, messages:, stream: false, **opts, &block)
+        def responses(model:, body:, messages:, stream: false, **opts, &)
           payload = build_responses_payload(
-            body: body,
-            model: model,
+            body:     body,
+            model:    model,
             messages: messages,
-            stream: stream,
-            system: opts[:system],
-            tools: opts[:tools]
+            stream:   stream,
+            system:   opts[:system],
+            tools:    opts[:tools]
           )
 
           if stream
-            stream_responses_payload(payload, offering_metadata: opts[:offering_metadata], &block)
+            stream_responses_payload(payload, offering_metadata: opts[:offering_metadata], &)
           else
             response = provider.connection.post(responses_url, payload)
             responses_hash_response(response.body, offering_metadata: opts[:offering_metadata])

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'event_stream_parser'
 require 'legion/logging/helper'
 
 module Legion
@@ -55,6 +56,24 @@ module Legion
             message_response(response, offering_metadata: opts[:offering_metadata])
           else
             chunk_response(accumulator, offering_metadata: opts[:offering_metadata])
+          end
+        end
+
+        def responses(model:, body:, messages:, stream: false, **opts, &block)
+          payload = build_responses_payload(
+            body: body,
+            model: model,
+            messages: messages,
+            stream: stream,
+            system: opts[:system],
+            tools: opts[:tools]
+          )
+
+          if stream
+            stream_responses_payload(payload, offering_metadata: opts[:offering_metadata], &block)
+          else
+            response = provider.connection.post(responses_url, payload)
+            responses_hash_response(response.body, offering_metadata: opts[:offering_metadata])
           end
         end
 
@@ -134,6 +153,207 @@ module Legion
           else
             provider.image(**args.except(:headers))
           end
+        end
+
+        def responses_url = '/v1/responses'
+
+        def build_responses_payload(body:, model:, messages:, stream:, system: nil, tools: nil)
+          payload = normalize_hash(body).dup
+          payload[:model] = model
+          payload[:stream] = stream
+          payload[:input] = responses_input(messages)
+
+          system_content = normalize_response_system(system)
+          payload[:instructions] = system_content if present_system?(system_content)
+
+          formatted_tools = responses_tools(tools)
+          payload[:tools] = formatted_tools if formatted_tools.any?
+
+          deep_compact(payload)
+        end
+
+        def responses_input(messages)
+          Array(messages).map do |message|
+            normalized = normalize_hash(message)
+            if normalized[:role].to_s == 'tool'
+              next({
+                type:    'function_call_output',
+                call_id: normalized[:tool_call_id].to_s,
+                output:  normalize_message_content(normalized[:content]).to_s
+              })
+            end
+
+            {
+              role:         normalized[:role]&.to_s || 'user',
+              content:      normalize_message_content(normalized[:content]).to_s,
+              tool_call_id: normalized[:tool_call_id]
+            }.compact
+          end
+        end
+
+        def normalize_response_system(system)
+          return nil if system.nil?
+          return system[:content] || system['content'] if system.is_a?(Hash)
+
+          system.to_s
+        end
+
+        def responses_tools(tools)
+          normalize_tools(tools).values.map do |tool|
+            {
+              type:        'function',
+              name:        tool.name.to_s,
+              description: tool.description.to_s,
+              parameters:  tool.params_schema || { type: 'object', properties: {} }
+            }
+          end
+        end
+
+        def deep_compact(value)
+          case value
+          when Hash
+            value.each_with_object({}) do |(key, hash_value), compacted|
+              compact_value = deep_compact(hash_value)
+              compacted[key] = compact_value unless compact_value.nil?
+            end
+          when Array
+            value.map { |entry| deep_compact(entry) }.compact
+          else
+            value
+          end
+        end
+
+        def stream_responses_payload(payload, offering_metadata: nil, &block)
+          accumulator = build_responses_stream_accumulator
+          parser = EventStreamParser::Parser.new
+
+          response = provider.connection.post(responses_url, payload) do |req|
+            req.headers['Accept'] = 'text/event-stream'
+            attach_responses_stream_handler(req, parser, accumulator, block)
+          end
+
+          responses_stream_response(accumulator, response.body, offering_metadata: offering_metadata)
+        end
+
+        def build_responses_stream_accumulator
+          {
+            content:   +'',
+            model:     nil,
+            usage:     {},
+            completed: nil,
+            raw:       nil
+          }
+        end
+
+        def attach_responses_stream_handler(req, parser, accumulator, block)
+          handler = proc do |chunk, *_args|
+            parser.feed(chunk) do |_event, data|
+              handle_responses_stream_data(data, accumulator, block)
+            end
+          end
+
+          if req.options.respond_to?(:on_data=)
+            req.options.on_data = handler
+          else
+            req.options[:on_data] = handler
+          end
+        end
+
+        def handle_responses_stream_data(data, accumulator, block)
+          return if data == '[DONE]'
+
+          parsed = Legion::JSON.parse(data, symbolize_names: false)
+          return unless parsed.is_a?(Hash)
+
+          accumulator[:raw] = parsed
+          case parsed['type']
+          when 'response.output_text.delta'
+            accumulate_responses_text_delta(parsed, accumulator, block)
+          when 'response.completed'
+            response = parsed['response'] || {}
+            accumulator[:completed] = response
+            accumulator[:model] = response['model'] if response['model']
+            accumulator[:usage] = responses_usage(response['usage'])
+          end
+        end
+
+        def accumulate_responses_text_delta(parsed, accumulator, block)
+          delta = parsed['delta'].to_s
+          return if delta.empty?
+
+          accumulator[:content] << delta
+          block&.call(
+            lex_llm_namespace::Chunk.new(
+              role:     :assistant,
+              content:  delta,
+              model_id: parsed['model'],
+              raw:      parsed,
+              tokens:   nil
+            )
+          )
+        end
+
+        def responses_stream_response(accumulator, response_body, offering_metadata: nil)
+          completed = accumulator[:completed] || {}
+          content = accumulator[:content]
+          content = extract_responses_text(completed) if content.empty?
+
+          {
+            result:   content,
+            model:    accumulator[:model] || completed['model'],
+            usage:    accumulator[:usage],
+            metadata: response_metadata(completed.empty? ? response_body : completed, offering_metadata: offering_metadata)
+          }.compact
+        end
+
+        def responses_hash_response(body, offering_metadata: nil)
+          normalized = normalize_string_hash(body)
+          {
+            result:   extract_responses_text(normalized),
+            model:    normalized['model'],
+            usage:    responses_usage(normalized['usage']),
+            metadata: response_metadata(normalized, offering_metadata: offering_metadata)
+          }.compact
+        end
+
+        def normalize_string_hash(value)
+          return value.map { |entry| normalize_string_hash(entry) } if value.is_a?(Array)
+          return {} unless value.respond_to?(:each_pair)
+
+          value.each_with_object({}) do |(key, hash_value), normalized|
+            normalized[key.to_s] = normalize_string_hash_value(hash_value)
+          end
+        end
+
+        def normalize_string_hash_value(value)
+          return normalize_string_hash(value) if value.respond_to?(:each_pair)
+          return value.map { |entry| normalize_string_hash_value(entry) } if value.is_a?(Array)
+
+          value
+        end
+
+        def extract_responses_text(body)
+          return body['output_text'].to_s if body['output_text']
+
+          Array(body['output']).flat_map do |item|
+            Array(item['content']).filter_map do |content|
+              next unless %w[output_text text].include?(content['type'].to_s)
+
+              content['text']
+            end
+          end.join
+        end
+
+        def responses_usage(usage)
+          usage = normalize_string_hash(usage)
+          input = usage['input_tokens'] || usage['prompt_tokens']
+          output = usage['output_tokens'] || usage['completion_tokens']
+          {
+            input_tokens:       input.to_i,
+            output_tokens:      output.to_i,
+            cache_read_tokens:  usage.dig('input_tokens_details', 'cached_tokens').to_i,
+            cache_write_tokens: usage.dig('input_tokens_details', 'cache_creation_tokens').to_i
+          }
         end
 
         def model_info(model, offering_metadata: nil)

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -124,6 +124,14 @@ module Legion
           build_response
         end
 
+        def call_responses(body:, stream: false, &block)
+          log.debug "[llm][executor] action=call_responses request_id=#{@request.id} profile=#{@profile} stream=#{stream}"
+          execute_pre_provider_steps
+          execute_provider_request_responses(body: body, stream: stream, &block)
+          execute_post_provider_steps
+          build_response
+        end
+
         private
 
         def llm_setting(key, default = nil)
@@ -1337,6 +1345,32 @@ module Legion
           result = execute_native_streaming_tool_loop(&)
           merge_response_offering_metadata(result[:metadata])
           @raw_response = Call::NativeResponseAdapter.new(result)
+        end
+
+        def execute_provider_request_responses(body:, stream:, &block)
+          @timestamps[:provider_start] = Time.now
+          @timeline.record(
+            category: :provider, key: 'provider:request_sent',
+            exchange_id: @exchange_id, direction: :outbound,
+            detail: "responses from #{@resolved_provider}",
+            from: 'pipeline', to: "provider:#{@resolved_provider}"
+          )
+
+          unless use_native_dispatch?(@resolved_provider)
+            raise Legion::LLM::ProviderError, "Native provider not registered: #{@resolved_provider}"
+          end
+
+          result = dispatch_responses_request(
+            body:         body,
+            messages:     native_dispatch_messages,
+            stream:       stream,
+            stream_block: block
+          )
+          merge_response_offering_metadata(result[:metadata])
+          @raw_response = Call::NativeResponseAdapter.new(result)
+
+          @timestamps[:provider_end] = Time.now
+          record_provider_response
         end
 
         def normalize_message_content(content)

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -124,10 +124,10 @@ module Legion
           build_response
         end
 
-        def call_responses(body:, stream: false, &block)
+        def call_responses(body:, stream: false, &)
           log.debug "[llm][executor] action=call_responses request_id=#{@request.id} profile=#{@profile} stream=#{stream}"
           execute_pre_provider_steps
-          execute_provider_request_responses(body: body, stream: stream, &block)
+          execute_provider_request_responses(body: body, stream: stream, &)
           execute_post_provider_steps
           build_response
         end
@@ -1356,9 +1356,7 @@ module Legion
             from: 'pipeline', to: "provider:#{@resolved_provider}"
           )
 
-          unless use_native_dispatch?(@resolved_provider)
-            raise Legion::LLM::ProviderError, "Native provider not registered: #{@resolved_provider}"
-          end
+          raise Legion::LLM::ProviderError, "Native provider not registered: #{@resolved_provider}" unless use_native_dispatch?(@resolved_provider)
 
           result = dispatch_responses_request(
             body:         body,

--- a/lib/legion/llm/inference/route_attempts.rb
+++ b/lib/legion/llm/inference/route_attempts.rb
@@ -24,6 +24,41 @@ module Legion
           end
         end
 
+        def dispatch_responses_request(body:, messages:, stream:, stream_block: nil)
+          raise Legion::LLM::ProviderError, 'Responses API upstream dispatch is not supported for fleet providers' if fleet_dispatch?
+
+          idempotency_key = next_route_idempotency_key
+          result = Call::Dispatch.call(
+            provider:   @resolved_provider,
+            instance:   @resolved_instance,
+            capability: :responses,
+            model:      @resolved_model,
+            body:       body,
+            messages:   messages,
+            stream:     stream,
+            **native_dispatch_options,
+            &stream_block
+          )
+          record_route_attempt(
+            dispatch_path:   :direct,
+            operation:       :responses,
+            status:          :success,
+            idempotency_key: idempotency_key,
+            selected_lane:   nil
+          )
+          result
+        rescue StandardError => e
+          record_route_attempt(
+            dispatch_path:   :direct,
+            operation:       :responses,
+            status:          :failure,
+            idempotency_key: idempotency_key,
+            selected_lane:   nil,
+            failure_reason:  e.message
+          )
+          raise
+        end
+
         def dispatch_direct_request(capability:, operation:, messages:, stream_block: nil)
           idempotency_key = next_route_idempotency_key
           result = Call::Dispatch.call(

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.36'
+    VERSION = '0.9.37'
   end
 end

--- a/spec/legion/llm/api/openai/responses_spec.rb
+++ b/spec/legion/llm/api/openai/responses_spec.rb
@@ -132,6 +132,35 @@ RSpec.describe Legion::LLM::API::OpenAI::Responses do
         total_tokens:  19
       )
     end
+
+    it 'uses Responses upstream executor path when an upstream body is provided' do
+      pipeline_response = double(
+        'PipelineResponse',
+        routing: { model: 'gpt-5.4' },
+        tokens:  { input_tokens: 8, output_tokens: 5 }
+      )
+      executor = double('Executor')
+      out = +''
+
+      allow(executor).to receive(:respond_to?).with(:call_responses).and_return(true)
+      allow(executor).to receive(:call_responses) do |body:, stream:, &block|
+        block.call('hi')
+        expect(body).to eq(input: 'say hi', stream: true)
+        expect(stream).to be(true)
+        pipeline_response
+      end
+
+      described_class.stream_response(
+        out,
+        executor,
+        request_id:    'resp_stream',
+        model:         'gpt-5.4',
+        upstream_body: { input: 'say hi', stream: true }
+      )
+
+      expect(executor).to have_received(:call_responses)
+      expect(out).to include('event: response.completed')
+    end
   end
 
   describe '.extract_token' do

--- a/spec/legion/llm/call/dispatch_capability_spec.rb
+++ b/spec/legion/llm/call/dispatch_capability_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Legion::LLM::Call::Dispatch, '.call' do
         { content: 'streamed response', usage: { input_tokens: 8, output_tokens: 4 } }
       end
 
+      def responses(model:, body:, messages:, stream:, **) # rubocop:disable Lint/UnusedMethodArgument
+        { content: 'responses response', usage: { input_tokens: 11, output_tokens: 6 } }
+      end
+
       def image(model:, prompt:, size:, **) # rubocop:disable Lint/UnusedMethodArgument
         { result: [{ url: 'https://images.invalid/generated.png' }], model: model, usage: {} }
       end
@@ -60,6 +64,16 @@ RSpec.describe Legion::LLM::Call::Dispatch, '.call' do
       expect(result[:result]).to eq('streamed response')
       expect(result[:usage].output_tokens).to eq(4)
       expect(chunks).to eq(['chunk'])
+    end
+
+    it 'dispatches responses capability — calls ext.responses' do
+      result = described_class.call(
+        provider: :ollama, capability: :responses, instance: :local,
+        model: 'llama3', body: { input: 'hi' }, messages: [{ role: 'user', content: 'hi' }], stream: false
+      )
+
+      expect(result[:result]).to eq('responses response')
+      expect(result[:usage].input_tokens).to eq(11)
     end
 
     it 'dispatches image capability — calls ext.image' do

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -51,8 +51,12 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
         { status: live ? 'healthy' : 'unknown', ready: live }
       end
 
+      def connection
+        self.class.connection || super
+      end
+
       class << self
-        attr_accessor :last_embed_call
+        attr_accessor :connection, :last_embed_call
       end
     end
   end
@@ -165,6 +169,79 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
     expect(result[:result]).to eq('hello')
     expect(result[:model]).to eq('model-a')
     expect(result[:usage]).to include(input_tokens: 7, output_tokens: 3)
+  end
+
+  it 'calls upstream Responses API for non-streaming responses' do
+    connection = Class.new do
+      attr_reader :url, :payload
+
+      def post(url, payload)
+        @url = url
+        @payload = payload
+        response_body = {
+          'model'  => 'gpt-5.4',
+          'output' => [
+            { 'content' => [{ 'type' => 'output_text', 'text' => 'hi' }] }
+          ],
+          'usage'  => { 'input_tokens' => 8, 'output_tokens' => 5 }
+        }
+        Struct.new(:body).new(response_body)
+      end
+    end.new
+    provider_class.connection = connection
+
+    result = adapter.responses(
+      model:    'gpt-5.4',
+      body:     { input: 'say hi', stream: false },
+      messages: [{ role: 'user', content: 'say hi' }]
+    )
+
+    expect(connection.url).to eq('/v1/responses')
+    expect(connection.payload).to include(model: 'gpt-5.4', stream: false)
+    expect(connection.payload[:input]).to eq([{ role: 'user', content: 'say hi' }])
+    expect(result[:result]).to eq('hi')
+    expect(result[:usage]).to include(input_tokens: 8, output_tokens: 5)
+  ensure
+    provider_class.connection = nil
+  end
+
+  it 'streams upstream Responses API deltas and captures completed usage' do
+    connection = Class.new do
+      attr_reader :payload
+
+      def post(_url, payload)
+        @payload = payload
+        options = Struct.new(:on_data, keyword_init: true).new
+        request = Struct.new(:headers, :options, keyword_init: true).new(headers: {}, options: options)
+        yield request
+        request.options.on_data.call(sse('response.output_text.delta', type: 'response.output_text.delta', delta: 'hi'))
+        request.options.on_data.call(sse('response.completed',
+                                         type:     'response.completed',
+                                         response: { model: 'gpt-5.4', usage: { input_tokens: 8, output_tokens: 5 } }))
+        Struct.new(:body).new(nil)
+      end
+
+      def sse(event, payload)
+        "event: #{event}\ndata: #{Legion::JSON.dump(payload)}\n\n"
+      end
+    end.new
+    provider_class.connection = connection
+
+    yielded = []
+    result = adapter.responses(
+      model:    'gpt-5.4',
+      body:     { input: 'say hi', stream: true },
+      stream:   true,
+      messages: [{ role: 'user', content: 'say hi' }]
+    ) { |chunk| yielded << chunk.content }
+
+    expect(connection.payload).to include(model: 'gpt-5.4', stream: true)
+    expect(yielded).to eq(['hi'])
+    expect(result[:result]).to eq('hi')
+    expect(result[:model]).to eq('gpt-5.4')
+    expect(result[:usage]).to include(input_tokens: 8, output_tokens: 5)
+  ensure
+    provider_class.connection = nil
   end
 
   it 'uses the final streamed provider message for accumulated tool calls' do


### PR DESCRIPTION
## Summary
- dispatch OpenAI Responses API requests through a native responses provider capability
- post upstream to /v1/responses instead of adapting through chat completions stream_chat
- preserve Responses streaming usage from response.completed.response.usage
- bump legion-llm to 0.9.37 and update CHANGELOG.md

## Validation
- git diff --check
- Ruby syntax checks for touched lib/spec files
- direct Ruby harness validated streamed Responses usage propagation