### PR TITLE
feat: add /api/llm/inference/v1 prefix for OpenAI-compatible endpoints (v0.9.53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion LLM Changelog
 
+## [0.9.53] - 2026-05-29
+
+### Added
+- API: OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/models`, `/v1/embeddings`, `/v1/responses`) are now also available under the `/api/llm/inference/v1/` prefix, allowing Mastra `openai-compatible` providers to use `http://127.0.0.1:4567/api/llm/inference` as the base URL — consistent with the Claude and Codex client routing patches in legion-interlink
+- API: auth `before` filter extended to cover `/api/llm/inference/v1/*` in addition to `/v1/*`
+
 ## [0.9.52] - 2026-05-27
 
 ### Fixed

--- a/lib/legion/llm/api/auth.rb
+++ b/lib/legion/llm/api/auth.rb
@@ -9,9 +9,9 @@ module Legion
         extend Legion::Logging::Helper
 
         def self.registered(app)
-          log.debug('[llm][api][auth] registering /v1/* before filter')
+          log.debug('[llm][api][auth] registering /v1/* and /api/llm/inference/v1/* before filters')
 
-          app.before '/v1/*' do
+          auth_check = proc do
             log.debug("[llm][api][auth] before filter action=check path=#{request.path_info}")
             next unless auth_enabled?
 
@@ -26,6 +26,10 @@ module Legion
 
             log.debug("[llm][api][auth] action=authorized path=#{request.path_info}")
           end
+
+          app.before('/api/llm/inference/v1/*', &auth_check)
+
+          app.before('/v1/*', &auth_check)
 
           app.helpers do
             define_method(:auth_enabled?) do
@@ -53,7 +57,7 @@ module Legion
             end
           end
 
-          log.debug('[llm][api][auth] /v1/* before filter registered')
+          log.debug('[llm][api][auth] /v1/* and /api/llm/inference/v1/* before filters registered')
         rescue StandardError => e
           handle_exception(e, level: :error, handled: false, operation: 'llm.api.auth.register')
         end

--- a/lib/legion/llm/api/openai/chat_completions.rb
+++ b/lib/legion/llm/api/openai/chat_completions.rb
@@ -12,9 +12,18 @@ module Legion
           extend Legion::Logging::Helper
 
           def self.registered(app) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-            log.debug('[llm][api][openai][chat_completions] registering POST /v1/chat/completions')
+            log.debug('[llm][api][openai][chat_completions] registering POST /v1/chat/completions + /api/llm/inference/v1/chat/completions')
 
-            app.post '/v1/chat/completions' do # rubocop:disable Metrics/BlockLength
+            handler = build_handler
+
+            app.post('/v1/chat/completions') { instance_exec(&handler) }
+            app.post('/api/llm/inference/v1/chat/completions') { instance_exec(&handler) }
+
+            log.debug('[llm][api][openai][chat_completions] routes registered')
+          end
+
+          def self.build_handler # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+            proc do # rubocop:disable Metrics/BlockLength
               require_llm!
               body = parse_request_body
 
@@ -121,8 +130,6 @@ module Legion
               halt 500, { 'Content-Type' => 'application/json' },
                    Legion::JSON.dump({ error: { message: e.message, type: 'server_error' } })
             end
-
-            log.debug('[llm][api][openai][chat_completions] POST /v1/chat/completions registered')
           end
 
           def self.build_openai_tool_classes(tools)

--- a/lib/legion/llm/api/openai/chat_completions.rb
+++ b/lib/legion/llm/api/openai/chat_completions.rb
@@ -11,7 +11,7 @@ module Legion
         module ChatCompletions
           extend Legion::Logging::Helper
 
-          def self.registered(app) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+          def self.registered(app)
             log.debug('[llm][api][openai][chat_completions] registering POST /v1/chat/completions + /api/llm/inference/v1/chat/completions')
 
             handler = build_handler

--- a/lib/legion/llm/api/openai/embeddings.rb
+++ b/lib/legion/llm/api/openai/embeddings.rb
@@ -10,9 +10,18 @@ module Legion
           extend Legion::Logging::Helper
 
           def self.registered(app)
-            log.debug('[llm][api][openai][embeddings] registering POST /v1/embeddings')
+            log.debug('[llm][api][openai][embeddings] registering POST /v1/embeddings + /api/llm/inference/v1/embeddings')
 
-            app.post '/v1/embeddings' do
+            handler = build_handler
+
+            app.post('/v1/embeddings') { instance_exec(&handler) }
+            app.post('/api/llm/inference/v1/embeddings') { instance_exec(&handler) }
+
+            log.debug('[llm][api][openai][embeddings] routes registered')
+          end
+
+          def self.build_handler
+            proc do
               require_llm!
               body = parse_request_body
 
@@ -57,8 +66,6 @@ module Legion
               halt 500, { 'Content-Type' => 'application/json' },
                    Legion::JSON.dump({ error: { message: e.message, type: 'server_error' } })
             end
-
-            log.debug('[llm][api][openai][embeddings] POST /v1/embeddings registered')
           end
         end
       end

--- a/lib/legion/llm/api/openai/models.rb
+++ b/lib/legion/llm/api/openai/models.rb
@@ -11,9 +11,9 @@ module Legion
           extend Legion::Logging::Helper
 
           def self.registered(app)
-            log.debug('[llm][api][openai][models] registering GET /v1/models and GET /v1/models/:id')
+            log.debug('[llm][api][openai][models] registering GET /v1/models + /api/llm/inference/v1/models routes')
 
-            app.get '/v1/models' do
+            list_handler = proc do
               log.debug('[llm][api][openai][models] action=list')
               require_llm!
 
@@ -28,7 +28,7 @@ module Legion
                    Legion::JSON.dump({ error: { message: e.message, type: 'server_error' } })
             end
 
-            app.get '/v1/models/:id' do
+            get_handler = proc do
               model_id = params[:id]
               log.debug("[llm][api][openai][models] action=get id=#{model_id}")
               require_llm!
@@ -52,7 +52,12 @@ module Legion
                    Legion::JSON.dump({ error: { message: e.message, type: 'server_error' } })
             end
 
-            log.debug('[llm][api][openai][models] GET /v1/models routes registered')
+            app.get('/v1/models') { instance_exec(&list_handler) }
+            app.get('/api/llm/inference/v1/models') { instance_exec(&list_handler) }
+            app.get('/v1/models/:id') { instance_exec(&get_handler) }
+            app.get('/api/llm/inference/v1/models/:id') { instance_exec(&get_handler) }
+
+            log.debug('[llm][api][openai][models] routes registered')
           end
 
           def self.build_model_list

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.52'
+    VERSION = '0.9.53'
   end
 end


### PR DESCRIPTION
## Summary
- Mount OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/models`, `/v1/embeddings`, `/v1/responses`) at `/api/llm/inference/v1/*` in addition to the existing `/v1/*` paths — same handler, no logic duplication
- Extend the auth `before` filter to cover the new `/api/llm/inference/v1/*` prefix
- Bump version to `0.9.53`

## Motivation

legion-interlink patches `~/.kai/settings/desktop.json` to route Kai through LegionIO. The `legionio` provider is `type: "openai-compatible"` and Mastra appends `/v1/chat/completions` to the base URL. Using `http://127.0.0.1:4567/api/llm/inference` as the base — the same URL as the native endpoint and consistent with how Claude Code and Codex are patched — requires the chat completions route to exist under that prefix.

## Implementation

Used the existing `build_handler` / `instance_exec` pattern already in `responses.rb` to register the same proc at both paths. No logic is duplicated. Auth coverage follows automatically from the extended before-filter.

## Route table after this change

| Method | Path | Notes |
|--------|------|-------|
| POST | `/v1/chat/completions` | existing |
| POST | `/api/llm/inference/v1/chat/completions` | **new** |
| GET  | `/v1/models` | existing |
| GET  | `/api/llm/inference/v1/models` | **new** |
| POST | `/v1/embeddings` | existing |
| POST | `/api/llm/inference/v1/embeddings` | **new** |
| POST | `/v1/responses` | existing |
| POST | `/api/llm/inference/v1/responses` | existing (responses.rb already had this) |

## Test plan
- [ ] `POST /api/llm/inference/v1/chat/completions` with `stream: false` returns valid chat completion JSON
- [ ] `POST /api/llm/inference/v1/chat/completions` with `stream: true` streams SSE chunks and terminates with `data: [DONE]`
- [ ] `GET /api/llm/inference/v1/models` returns the model list
- [ ] Existing `/v1/*` paths unaffected
- [ ] Auth rejection (401) works on `/api/llm/inference/v1/*` when auth is enabled
- [ ] legion-interlink Kai routing toggle with `endpoint: "http://127.0.0.1:4567/api/llm/inference"` routes correctly through Kai

🤖 Generated with [Claude Code](https://claude.com/claude-code)