### PR TITLE
feat: include token usage in streaming done_chunk (v0.9.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.9.54] - 2026-05-29
+
+### Fixed
+- API: OpenAI-compatible streaming responses now include `usage` (`prompt_tokens`, `completion_tokens`, `total_tokens`) in the final done-chunk, allowing the Vercel AI SDK `step-finish` event to propagate token counts to clients (fixes empty Tokens display in Kai's response info popup)
+
 ## [0.9.53] - 2026-05-29
 
 ### Added

--- a/lib/legion/llm/api/openai/chat_completions.rb
+++ b/lib/legion/llm/api/openai/chat_completions.rb
@@ -91,7 +91,13 @@ module Legion
                     nil,
                     model:         final_model,
                     request_id:    request_id,
-                    finish_reason: tool_calls.empty? ? 'stop' : 'tool_calls'
+                    finish_reason: tool_calls.empty? ? 'stop' : 'tool_calls',
+                    usage:         {
+                      prompt_tokens:     Legion::LLM::API::Translators::OpenAIResponse.extract_token_count(pipeline_response.tokens, :input),
+                      completion_tokens: Legion::LLM::API::Translators::OpenAIResponse.extract_token_count(pipeline_response.tokens, :output),
+                      total_tokens:      Legion::LLM::API::Translators::OpenAIResponse.extract_token_count(pipeline_response.tokens, :input).to_i +
+                                         Legion::LLM::API::Translators::OpenAIResponse.extract_token_count(pipeline_response.tokens, :output).to_i
+                    }
                   )
                   out << "data: #{Legion::JSON.dump(done_chunk)}\n\n"
                   out << "data: [DONE]\n\n"

--- a/lib/legion/llm/api/translators/openai_response.rb
+++ b/lib/legion/llm/api/translators/openai_response.rb
@@ -57,17 +57,19 @@ module Legion
             }
           end
 
-          def format_stream_chunk(delta_text, model:, request_id:, finish_reason: nil)
+          def format_stream_chunk(delta_text, model:, request_id:, finish_reason: nil, usage: nil)
             choice = { index: 0, delta: {}, finish_reason: finish_reason }
             choice[:delta][:content] = delta_text if delta_text && !delta_text.empty?
 
-            {
+            chunk = {
               id:      "chatcmpl-#{request_id.delete('-')}",
               object:  'chat.completion.chunk',
               created: Time.now.to_i,
               model:   model.to_s,
               choices: [choice]
             }
+            chunk[:usage] = usage if usage
+            chunk
           end
 
           def format_stream_tool_call_chunk(tool_call, model:, request_id:, index:)

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.9.53'
+    VERSION = '0.9.54'
   end
 end


### PR DESCRIPTION
## Summary

- `format_stream_chunk` now accepts an optional `usage:` keyword argument and includes it in the chunk when present
- The final done-chunk in `/v1/chat/completions` (and `/api/llm/inference/v1/chat/completions`) now passes `prompt_tokens`, `completion_tokens`, and `total_tokens` from `pipeline_response.tokens`
- The Vercel AI SDK reads token counts from the `step-finish` event's `payload.usage` — this was the missing link causing the Tokens row to be empty in Kai's response info popup
- Bumps version to `0.9.54`

## Test plan

- [ ] Streaming response: final SSE chunk has `usage.prompt_tokens` and `usage.completion_tokens` populated
- [ ] Non-streaming response: `usage` in JSON body unchanged (already worked)
- [ ] Kai response info popup shows token counts (e.g. `2.3k (1.8k in · 512 out)`) after a streaming exchange

🤖 Generated with [Claude Code](https://claude.com/claude-code)