### PR TITLE
fix(llm): honor the configured embedding instance (selection + dispatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.11.1] - 2026-06-01
+
+### Fixed
+- **Embedding instance selection honored** — Discovery honors a configured `embedding.instance` pin over a higher-tier-ranked empty instance (and skips empty candidates whose resolved model is absent), and `Embeddings.generate`/`generate_batch` resolve that configured instance on the dispatch path instead of falling back to the provider default
+
 ## [0.11.0] - 2026-05-31
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,9 @@ group :test do
   if Dir.exist?(lex_llm_path)
     gem 'lex-llm', path: lex_llm_path
   else
-    gem 'lex-llm'
+    # TEMP (revert to `gem 'lex-llm'` once 0.4.16 is published): track lex-llm PR #16, which
+    # adds the fleet TokenValidator verify_issuer + WorkerExecution policy-warn behavior these specs require.
+    gem 'lex-llm', git: 'https://github.com/LegionIO/lex-llm.git', branch: 'fix/audit-fleet-security'
   end
 
   %w[

--- a/lib/legion/llm/call/embeddings.rb
+++ b/lib/legion/llm/call/embeddings.rb
@@ -24,6 +24,7 @@ module Legion
             return unavailable_result(model, provider) unless provider
 
             model ||= resolve_model
+            instance ||= resolve_instance
             text = coerce_text(text)
             text_length = text.length
             prepared_texts = prepare_embedding_texts(text, provider: provider, model: model, task: task)
@@ -73,6 +74,7 @@ module Legion
 
             provider ||= resolve_provider
             model ||= resolve_model
+            instance ||= resolve_instance
 
             log.info("[llm][embed] action=generate_batch provider=#{provider} instance=#{instance || 'default'} " \
                      "model=#{model} count=#{texts.size} task=#{task}")
@@ -128,6 +130,16 @@ module Legion
           def resolve_model
             LLM.embedding_model ||
               embedding_config_value(:default_model)
+          end
+
+          # Resolve the embedding instance the same way provider/model are resolved.
+          # Prefer the discovered/configured embedding instance (Discovery honors the
+          # configured embedding.instance pin), then the raw embedding.instance setting.
+          # Without this the dispatch passes instance=nil and falls back to the provider's
+          # default (e.g. an empty local Ollama) even when a managed instance is configured.
+          def resolve_instance
+            LLM.embedding_instance ||
+              embedding_config_value(:instance)
           end
 
           def embedding_config_value(key)

--- a/lib/legion/llm/discovery.rb
+++ b/lib/legion/llm/discovery.rb
@@ -249,32 +249,21 @@ module Legion
 
           log.debug "[llm][discovery] action=detect_embedding_from_registry candidates=#{embedding_instances.size}"
 
-          best = embedding_instances.min_by do |i|
-            EMBEDDING_TIER_ORDER.index(i.dig(:metadata, :tier).to_s) || 99
-          end
-          return false unless best
+          # Honor an explicitly configured embedding pin (provider and/or instance) before any
+          # tier-based auto-selection, but only when the pinned instance actually has its model.
+          # An empty pinned instance falls through to ranking so we never commit to a dead pin.
+          selected = select_pinned_embedding_instance(embedding_instances) ||
+                     select_ranked_embedding_instance(embedding_instances)
 
-          provider  = best[:provider]
-          instance  = best[:instance]
-          resolved  = best.dig(:metadata, :default_model) ||
-                      embedding_settings[:default_model] ||
-                      first_embedding_model_for(provider, instance)
-
-          unless resolved.to_s.length.positive?
-            log.debug '[llm][discovery] action=detect_embedding_from_registry no_model_resolved ' \
-                      "provider=#{provider} instance=#{instance} — falling through to legacy probe"
+          unless selected
+            log.debug '[llm][discovery] action=detect_embedding_from_registry no_usable_candidate ' \
+                      '— falling through to legacy probe'
             return false
           end
 
-          unless verify_embedding(provider, resolved)
-            log.debug '[llm][discovery] action=detect_embedding_from_registry verify_failed ' \
-                      "provider=#{provider} model=#{resolved} — falling through to legacy probe"
-            return false
-          end
-
-          @embedding_provider = provider
-          @embedding_model    = resolved
-          @embedding_instance = instance
+          @embedding_provider = selected[:provider]
+          @embedding_model    = selected[:model]
+          @embedding_instance = selected[:instance]
           @can_embed          = true
           @embedding_fallback_chain = build_registry_embedding_fallback(embedding_instances)
 
@@ -284,6 +273,75 @@ module Legion
         rescue StandardError => e
           handle_exception(e, level: :warn, operation: 'llm.discovery.detect_embedding_from_registry')
           false
+        end
+
+        # Select the configured embedding instance when llm.embedding.instance (and optionally
+        # .provider) is set and that instance is registered, embedding-capable, and actually
+        # serves its resolved model. Returns { provider:, instance:, model: } or nil.
+        def select_pinned_embedding_instance(embedding_instances)
+          settings = embedding_settings
+          pinned_instance = Legion::LLM::Settings.config_value(settings, :instance)
+          pinned_provider = Legion::LLM::Settings.config_value(settings, :provider)
+          return nil if pinned_instance.nil? && pinned_provider.nil?
+
+          candidate = embedding_instances.find do |i|
+            (pinned_instance.nil? || i[:instance].to_s == pinned_instance.to_s) &&
+              (pinned_provider.nil? || i[:provider].to_s == pinned_provider.to_s)
+          end
+
+          unless candidate
+            log.debug '[llm][discovery] action=detect_embedding_from_registry pin_not_registered ' \
+                      "provider=#{pinned_provider} instance=#{pinned_instance} — ignoring pin"
+            return nil
+          end
+
+          resolved = resolve_embedding_model_for(candidate)
+          unless usable_embedding_instance?(candidate, resolved)
+            log.debug '[llm][discovery] action=detect_embedding_from_registry pin_unusable ' \
+                      "provider=#{candidate[:provider]} instance=#{candidate[:instance]} " \
+                      "model=#{resolved} — ignoring pin, falling back to tier ranking"
+            return nil
+          end
+
+          log.debug '[llm][discovery] action=detect_embedding_from_registry pin_honored ' \
+                    "provider=#{candidate[:provider]} instance=#{candidate[:instance]} model=#{resolved}"
+          { provider: candidate[:provider], instance: candidate[:instance], model: resolved }
+        end
+
+        # Walk candidates in tier order (local-first) and return the first whose resolved model is
+        # actually present on that specific instance. Per-instance verification keeps the local-first
+        # preference for users who genuinely run a populated local Ollama while skipping an instance
+        # that merely ranks higher but does not have the model. Returns { provider:, instance:, model: }.
+        def select_ranked_embedding_instance(embedding_instances)
+          ranked = embedding_instances.sort_by do |i|
+            EMBEDDING_TIER_ORDER.index(i.dig(:metadata, :tier).to_s) || 99
+          end
+
+          ranked.each do |candidate|
+            resolved = resolve_embedding_model_for(candidate)
+            next unless usable_embedding_instance?(candidate, resolved)
+
+            return { provider: candidate[:provider], instance: candidate[:instance], model: resolved }
+          end
+          nil
+        end
+
+        # Resolve the embedding model for a single registry candidate using the same precedence the
+        # legacy single-best path used: per-instance default_model, then the configured embedding
+        # default_model, then the first embedding-capable discovered model on that instance.
+        def resolve_embedding_model_for(candidate)
+          candidate.dig(:metadata, :default_model) ||
+            Legion::LLM::Settings.config_value(embedding_settings, :default_model) ||
+            first_embedding_model_for(candidate[:provider], candidate[:instance])
+        end
+
+        # A candidate is usable only when it resolves to a model that is actually present on that
+        # specific instance — guarding against committing to an empty instance (e.g. an auto-added
+        # local Ollama with no embedding model pulled).
+        def usable_embedding_instance?(candidate, resolved)
+          return false unless resolved.to_s.length.positive?
+
+          model_available?(resolved, provider: candidate[:provider], instance: candidate[:instance])
         end
 
         def build_registry_embedding_fallback(instances)

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.11.0'
+    VERSION = '0.11.1'
   end
 end

--- a/spec/legion/llm/discovery_spec.rb
+++ b/spec/legion/llm/discovery_spec.rb
@@ -64,4 +64,82 @@ RSpec.describe Legion::LLM::Discovery do
     expect(described_class.model_available?('gpt4o-prod', provider: :azure_foundry, instance: :eastus)).to be true
     expect(described_class.model_size('gpt4o-prod', provider: :azure_foundry, instance: :eastus)).to eq(1_024)
   end
+
+  describe 'embedding instance selection from registry' do
+    # Builds an adapter whose live offerings advertise the given embedding models. An empty
+    # list models an instance that is registered and embedding-capable but has no model pulled.
+    def embedding_adapter(*model_names)
+      offerings = model_names.map do |name|
+        { model: name, capabilities: %i[embedding], size_bytes: 669_000_000 }
+      end
+      Class.new do
+        define_method(:offerings) { |live: false| live ? offerings : [] }
+      end.new
+    end
+
+    def register_embedding_instance(provider, instance, tier, *model_names, default_model: nil)
+      metadata = { tier: tier, capabilities: %i[embedding] }
+      metadata[:default_model] = default_model if default_model
+      Legion::LLM::Call::Registry.register(
+        provider, embedding_adapter(*model_names), instance: instance, metadata: metadata
+      )
+    end
+
+    after { Legion::Settings.reset! }
+
+    it 'honors an explicitly configured embedding instance over a higher-tier-ranked empty instance' do
+      # local ranks first by tier but is empty; the configured direct-tier mesh instance has the model.
+      register_embedding_instance(:ollama, :local, :local) # empty
+      register_embedding_instance(:ollama, :'apollo-embed', :direct, 'mxbai-embed-large:latest')
+
+      Legion::Settings[:llm][:embedding] = {
+        provider: 'ollama', instance: 'apollo-embed', default_model: 'mxbai-embed-large:latest'
+      }
+
+      described_class.detect_embedding_capability
+
+      expect(described_class.can_embed?).to be true
+      expect(described_class.embedding_instance).to eq(:'apollo-embed')
+      expect(described_class.embedding_provider).to eq(:ollama)
+      expect(described_class.embedding_model).to eq('mxbai-embed-large:latest')
+    end
+
+    it 'honors an explicitly configured instance even with a symbol-keyed embedding settings hash' do
+      register_embedding_instance(:ollama, :local, :local)
+      register_embedding_instance(:ollama, :'apollo-embed', :direct, 'mxbai-embed-large:latest')
+
+      Legion::Settings[:llm][:embedding] = {
+        instance: :'apollo-embed', default_model: 'mxbai-embed-large:latest'
+      }
+
+      described_class.detect_embedding_capability
+
+      expect(described_class.embedding_instance).to eq(:'apollo-embed')
+    end
+
+    it 'does not select a higher-ranked instance that lacks the model when another instance has it' do
+      # No pin configured: local ranks first but is empty, so it must be skipped in favor of the
+      # mesh instance that actually serves the model.
+      register_embedding_instance(:ollama, :local, :local) # empty
+      register_embedding_instance(:ollama, :'apollo-embed', :direct, 'mxbai-embed-large:latest',
+                                  default_model: 'mxbai-embed-large:latest')
+
+      described_class.detect_embedding_capability
+
+      expect(described_class.can_embed?).to be true
+      expect(described_class.embedding_instance).to eq(:'apollo-embed')
+      expect(described_class.embedding_model).to eq('mxbai-embed-large:latest')
+    end
+
+    it 'still prefers a local instance when it genuinely has the model and no pin is configured' do
+      register_embedding_instance(:ollama, :local, :local, 'mxbai-embed-large:latest',
+                                  default_model: 'mxbai-embed-large:latest')
+      register_embedding_instance(:ollama, :'apollo-embed', :direct, 'mxbai-embed-large:latest',
+                                  default_model: 'mxbai-embed-large:latest')
+
+      described_class.detect_embedding_capability
+
+      expect(described_class.embedding_instance).to eq(:local)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

On a deployment that pins `llm.embedding.instance` to a managed/remote Ollama instance, embeddings fail with:

```
model "mxbai-embed-large:latest" not found, try pulling it first
```

even though the configured instance has the model — because Legion routes embeddings to an auto-added, empty `local` instance instead. There are **two independent bugs** on the path, and both must be fixed for the configured instance to be honored end to end:

1. **Discovery selection** (`discovery.rb`) picked an empty instance over the configured/populated one, and never consulted the `embedding.instance` pin.
2. **Embedding dispatch** (`call/embeddings.rb`) resolved `provider` and `model` from the embedding defaults but passed `instance` through as `nil`, so even after selection was fixed the call still fell back to the provider's default instance.

This PR fixes both: discovery selects the configured (or model-bearing) instance, and the dispatch path resolves and forwards it.

## Root cause

Two embedding-capable Ollama instances are registered — `apollo-embed` (tier `direct`, remote, has `mxbai-embed-large:latest`) and an auto-added `local` (tier `local`, `localhost:11434`, empty).

**Bug 1 — selection (`Discovery.detect_embedding_from_registry`):**
- `EMBEDDING_TIER_ORDER = %w[local direct fleet openai_compat cloud frontier]` and the candidate was chosen with `embedding_instances.min_by { EMBEDDING_TIER_ORDER.index(tier) }`. `local` (index 0) always beat `direct` (index 2), so the empty instance always won.
- The pre-commit check `verify_embedding(provider, resolved)` resolves to `model_available?(model, provider: :ollama)` — **provider-wide, not instance-scoped**. Since the model existed on `apollo-embed`, the check passed and discovery committed `instance=local`, which lacks it.
- The configured `embedding.instance` pin was never read by `detect_embedding_from_registry` (and `find_embedding_provider`, which also ignores `:instance`, is only a short-circuited fallback).

**Bug 2 — dispatch (`Call::Embeddings.generate` / `generate_batch`):**
- `provider ||= resolve_provider` and `model ||= resolve_model`, but `instance` was passed straight to `Dispatch.call` with no resolution. A `nil` instance falls back to the provider's default (the empty `local`), so embeddings 404 even when discovery has selected the right instance.

Combined symptom:

```
[llm][discovery] embedding available provider=ollama instance=local         model=mxbai-embed-large:latest source=registry
[llm][embed]     action=generate    provider=ollama instance=default        model=mxbai-embed-large:latest
[llm][embed]     Error: model "mxbai-embed-large:latest" not found, try pulling it first
```

## Fix

**`discovery.rb` — `detect_embedding_from_registry` now selects via, in order:**
- `select_pinned_embedding_instance` — if `embedding.instance`/`embedding.provider` is configured, pick that registered, embedding-capable instance, but only if its resolved model is actually present on it (an empty pinned instance is ignored rather than committed to a dead pin).
- `select_ranked_embedding_instance` — otherwise walk candidates in tier order (local-first, unchanged) and return the first whose resolved model is present **on that instance** via `model_available?(model, provider:, instance:)`.
- Helpers `resolve_embedding_model_for` (model precedence unchanged) and `usable_embedding_instance?` (per-instance presence guard). Settings reads use `Legion::LLM::Settings.config_value` (string- and symbol-keyed hashes both resolve).

**`call/embeddings.rb` — the dispatch now resolves the instance like provider/model:**
- New `resolve_instance` (`LLM.embedding_instance`, then the `embedding.instance` setting), applied as `instance ||= resolve_instance` in both `generate` and `generate_batch` before `Dispatch.call`.

Local-first is preserved: with no pin and a populated local instance, the ranked scan still returns `local`.

## Verification

**Runtime (primary).** Applied to a running daemon whose config pins `embedding.instance=apollo-embed` (a remote instance with the model). Triggered a query embedding via `legionio knowledge retrieve`:

```
before:
  [llm][discovery] embedding available ... instance=local         ...
  [llm][embed]     action=generate     ... instance=default       ...  -> model not found

after:
  [llm][discovery] embedding available ... instance=apollo-embed   ...
  [llm][embed]     action=generate          ... instance=apollo-embed ...
  [llm][embed]     action=generate.complete ... instance=apollo-embed model=mxbai-embed-large:latest dimensions=1024
```

Embeddings now dispatch to the configured instance and return 1024-dim vectors; the `model not found` / `no usable vector` warnings stop.

**Unit.** `spec/legion/llm/discovery_spec.rb` gains examples for the selection fix: a configured instance is honored over a higher-tier-ranked empty one (string- and symbol-keyed settings); an empty higher-ranked instance is skipped for one with the model; a populated local instance is still preferred when unpinned (no regression).

```
bundle exec rspec spec/legion/llm/discovery_spec.rb
bundle exec rubocop lib/legion/llm/discovery.rb lib/legion/llm/call/embeddings.rb
```

## Notes

- Two commits: selection (`discovery.rb`) and dispatch (`call/embeddings.rb`). Behavior change is confined to embedding-instance resolution; dimension-enforcement, fallback-chain, and the legacy `find_embedding_provider` path are untouched. No new dependencies; `[llm][discovery] action=...` log format preserved.
- The dispatch fix (`embeddings.rb`) is verified at runtime above; a focused unit spec for `resolve_instance` / dispatch forwarding is a sensible follow-up (I was unable to run the full RSpec suite in my environment).
