### PR TITLE
fix: skip all provider+model instances in chain on StandardError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion LLM Changelog
 
+## [0.12.3] - 2026-06-02
+
+### Fixed
+- **Escalation retries all instances of a broken provider** — When a `StandardError` fires during an escalation attempt (e.g. a code bug in the provider adapter), the loop previously retried every other registered instance of the same `provider+model` combination before giving up. New `skip_all_provider_model_instances!` marks all chain entries with the same `provider+model` as tried on the first `StandardError`, so escalation immediately advances to a different provider. Transient error paths (rate limit, auth, context overflow) are unaffected (inference/executor.rb)
+
 ## [0.12.2] - 2026-06-02
 
 ### Fixed

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -790,7 +790,7 @@ module Legion
                                     handled:   true)
           false
         rescue StandardError => e
-          tried << { provider: resolution.provider, instance: resolution.instance, model: resolution.model }
+          skip_all_provider_model_instances!(resolution, tried)
           record_escalation_failure(e, resolution, start_time,
                                     outcome:   :error,
                                     operation: 'llm.pipeline.escalation_attempt')
@@ -931,6 +931,20 @@ module Legion
             next if tried.any? { |t| t[:provider] == r.provider && t[:instance] == r.instance && t[:model] == r.model }
 
             log.debug "[llm][escalation] action=skip_same_tier provider=#{r.provider} model=#{r.model} tier=#{r.tier} reason=context_overflow"
+            tried << { provider: r.provider, instance: r.instance, model: r.model }
+          end
+        end
+
+        def skip_all_provider_model_instances!(failed_resolution, tried)
+          chain = @escalation_chain
+          return unless chain.respond_to?(:each)
+
+          chain.each do |r|
+            next if r.provider != failed_resolution.provider || r.model != failed_resolution.model
+            next if tried.any? { |t| t[:provider] == r.provider && t[:instance] == r.instance && t[:model] == r.model }
+
+            log.warn "[llm][escalation] action=skip_provider_model provider=#{r.provider} model=#{r.model} " \
+                     "instance=#{r.instance} reason=provider_error"
             tried << { provider: r.provider, instance: r.instance, model: r.model }
           end
         end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.12.2'
+    VERSION = '0.12.3'
   end
 end


### PR DESCRIPTION
## Summary
- When a `StandardError` fires during an escalation attempt (e.g. a code bug in the provider adapter), the escalation loop previously retried all other instances of the same `provider+model` (e.g. `bedrock/anthropic.claude-sonnet-4` with instances `nil`, `env_bearer`, `claude`) — burning all `max_attempts` on identically broken paths
- New `skip_all_provider_model_instances!` marks every chain entry with the same `provider+model` as tried, so escalation moves to a different provider immediately
- Transient errors (rate limit, auth, context overflow) are unaffected — they use specific rescues that only mark the failing instance

## Behaviour change
- **Before**: 3 bedrock instances × same `NoMethodError` = 3 failed attempts, `EscalationExhausted`
- **After**: 1st bedrock instance fails → all other bedrock instances for that model skipped → escalation proceeds to next provider in chain

## Test plan
- [ ] `bundle exec rspec spec/legion/llm/inference/executor_spec.rb` — 94 examples, 0 failures
- [ ] Confirm agentic escalation with a broken provider adapter skips to next provider after first failure