### PR TITLE
fix: PR #151 review findings — thread-safety, fail-closed availability, translator regressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -718,7 +718,7 @@ The legacy `vault_path` per-provider setting was removed in v0.3.1.
 Tests run without the full LegionIO stack. `spec/spec_helper.rb` uses real `Legion::Logging` and `Legion::Settings` (no stubs — hard dependencies are always present). Each test resets settings to defaults via `before(:each)`.
 
 ```bash
-bundle exec rspec    # 3044 examples, 0 failures
+bundle exec rspec    # all examples green, 0 failures
 bundle exec rubocop  # 0 offenses
 ```
 
@@ -729,7 +729,7 @@ bundle exec rubocop  # 0 offenses
 **The in-process matrix is the commit gate. Live e2e is confirmation only.**
 Every PR that touches `lib/legion/llm/api/`, the executor, or the canonical/translator boundary must pass the matrix locally before push. Live `legionio-e2e` runs against a daemon, costs cloud credits, and surfaces regressions hours after they ship — the matrix surfaces them in milliseconds with deterministic fixtures. If a regression breaks live e2e but not the matrix, the matrix is missing a scenario; add it.
 
-The harness has been proven to catch this week's translator-boundary regressions: `9771ae8` (ThinkingConfig kwargs), `cb7a08b` (flat tool_call hashes in OpenAI Responses), and `172c756` (reasoning output item shape). See `docs/work/planning/reports/G23-matrix-harness.md` for the proof and the scenario catalog.
+The harness has been proven to catch the P5 translator regressions: `9771ae8` (ThinkingConfig kwargs), `cb7a08b` (flat tool_call hashes in OpenAI Responses), and `172c756` (reasoning output item shape).
 
 ## LLM Routing Invariants
 
@@ -746,7 +746,7 @@ These are non-negotiable contracts that govern how requests flow through the dae
 
 4. **Thinking never crosses providers.** Reasoning content, signatures, and `redacted_thinking` blocks survive same-provider history replay; on any cross-provider transition (escalation, mid-stream failover, tier swap) thinking is stripped from replayed history. Signatures are cryptographically provider-bound and wire formats have no lossless mapping; foreign chain-of-thought is out-of-distribution for the new model.
 
-5. **Mid-stream provider failover is a first-class requirement.** A provider outage must never kill an in-flight conversation — that is vendor lock-in, not resiliency. The `StreamAssembler` decouples client protocol state from provider stream state: the client keeps one continuous SSE session while the canonical chunk source switches providers underneath. Failover phase points (`:before_first_byte`, `:mid_text`, `:mid_thinking`, `:mid_tool_call`) drive what the assembler replays vs. discards. Tool-call argument buffering policy (`llm.streaming.tool_call_buffering`) is configurable; the default is `:buffered` with periodic SSE keep-alive pings so large tool args don't make the upstream look dead.
+5. **Mid-stream provider failover is a first-class requirement.** A provider outage must never kill an in-flight conversation — that is vendor lock-in, not resiliency. The `StreamAssembler` decouples client protocol state from provider stream state: the client keeps one continuous SSE session while the canonical chunk source switches providers underneath. Failover phase points (`:before_first_byte`, `:mid_text`, `:mid_thinking`, `:mid_tool_call`) drive what the assembler replays vs. discards. Tool-call argument buffering policy (`llm.streaming.tool_call_buffering`) is configurable; the default is `:buffered`; a single keep-alive ping fires when a buffered tool-call opens (interval-based pinging is reserved but not yet implemented).
 
 6. **Every pipeline exit emits ledger events.** Every terminal path — success/sync, success/stream, error, escalation-exhausted, fleet-success, fleet-error, timeout, client-disconnect — routes through the same emission function and produces the metering, prompt-audit, and (for tool scenarios) tool-audit rows the ledger consumer expects. Pipeline bypasses are not allowed (the `_direct` shims are deprecated and route through the governed pipeline; see `Legion/Framework/NoDirectDispatch`). If you cannot record the event trail, fail closed when `llm.compliance.fail_closed` is set.
 

--- a/lib/legion/llm/api/client_translators/anthropic_messages.rb
+++ b/lib/legion/llm/api/client_translators/anthropic_messages.rb
@@ -97,11 +97,18 @@ module Legion
 
             messages = inference_messages(canonical_request.messages)
 
+            # C7 — header-supplied X-Legion-Model wins; otherwise fall back to
+            # the client-requested body[:model] so routing is never blank when
+            # the caller named a model.
+            routing = (canonical_request.routing || {}).dup
+            client_model = canonical_request.metadata[:client_model]
+            routing[:model] ||= client_model if client_model
+
             Legion::LLM::Inference::Request.build(
               id:              request_id,
               messages:        messages,
               system:          canonical_request.system,
-              routing:         canonical_request.routing,
+              routing:         routing,
               tools:           tool_defs,
               tool_choice:     canonical_request.tool_choice,
               caller:          server_caller,
@@ -462,6 +469,7 @@ module Legion
 
             text_parts = []
             tool_calls = []
+            thinking_blocks = []
 
             content.each do |block|
               bs = symbolize(block)
@@ -476,12 +484,13 @@ module Legion
                 # multi-turn replay R5 says signatures must round-trip on
                 # same-provider; leave them in the message for now (the
                 # provider translator drops them for cross-provider).
-                next
+                thinking_blocks << bs
               end
             end
 
             msg = { role: :assistant, content: text_parts.join("\n\n") }
             msg[:tool_calls] = tool_calls if tool_calls.any?
+            msg[:thinking_blocks] = thinking_blocks if thinking_blocks.any?
             [msg]
           end
 
@@ -491,6 +500,7 @@ module Legion
 
             messages = []
             text_parts = []
+            content_blocks = []
 
             content.each do |block|
               bs = symbolize(block)
@@ -499,9 +509,12 @@ module Legion
               when 'text'
                 text_parts << bs[:text].to_s
               when 'tool_result'
-                if text_parts.any?
-                  messages << { role: :user, content: text_parts.join("\n\n") }
+                if text_parts.any? || content_blocks.any?
+                  msg = { role: :user, content: text_parts.join("\n\n") }
+                  msg[:content_blocks] = content_blocks if content_blocks.any?
+                  messages << msg
                   text_parts = []
+                  content_blocks = []
                 end
                 result_content = bs[:content]
                 messages << if result_content.is_a?(Array)
@@ -510,11 +523,18 @@ module Legion
                               { role: :tool, tool_call_id: bs[:tool_use_id], content: result_content.to_s }
                             end
               else
-                text_parts << bs.to_s
+                # Preserve structured non-text blocks (image, document, …)
+                # rather than stringifying them — provider translators decide
+                # how to surface these per-modality.
+                content_blocks << bs
               end
             end
 
-            messages << { role: :user, content: text_parts.join } if text_parts.any?
+            if text_parts.any? || content_blocks.any?
+              msg = { role: :user, content: text_parts.join("\n\n") }
+              msg[:content_blocks] = content_blocks if content_blocks.any?
+              messages << msg
+            end
             messages.empty? ? [{ role: :user, content: '' }] : messages
           end
 

--- a/lib/legion/llm/api/client_translators/openai_chat.rb
+++ b/lib/legion/llm/api/client_translators/openai_chat.rb
@@ -91,11 +91,18 @@ module Legion
 
             messages = inference_messages(canonical_request.messages)
 
+            # C7 — header-supplied X-Legion-Model wins; otherwise fall back to
+            # the client-requested body[:model] so routing is never blank when
+            # the caller named a model.
+            routing = (canonical_request.routing || {}).dup
+            client_model = canonical_request.metadata[:client_model]
+            routing[:model] ||= client_model if client_model
+
             Legion::LLM::Inference::Request.build(
               id:              request_id,
               messages:        messages,
               system:          canonical_request.system,
-              routing:         canonical_request.routing,
+              routing:         routing,
               tools:           tool_defs,
               tool_choice:     canonical_request.tool_choice,
               caller:          server_caller,
@@ -225,6 +232,8 @@ module Legion
               @conv_id = conv_id
               @include_reasoning = include_reasoning
               @done_emitted = false
+              @tool_ordinal = -1
+              @tool_ordinals = {}
             end
 
             def on_start(model:, request_id:, input_tokens:)
@@ -269,12 +278,15 @@ module Legion
 
             def on_tool_call_open(block_index:, tool_call:, server_tool:)
               _ = server_tool
-              # Send the initial tool_call with name. Index is 0-based across
-              # this streaming response; chat.completion.chunk references it
-              # by index in the delta.
+              # Send the initial tool_call with name. Index is the 0-based
+              # tool-call ordinal across this streaming response (NOT the
+              # assembler's global block index); chat.completion.chunk
+              # references it by index in the delta.
+              idx = (@tool_ordinal += 1)
+              @tool_ordinals[block_index] = idx
               emit_chunk(delta_envelope({
                                           tool_calls: [{
-                                            index:    block_index,
+                                            index:    idx,
                                             id:       tool_call[:id],
                                             type:     'function',
                                             function: {
@@ -288,9 +300,10 @@ module Legion
             def on_tool_call_delta(block_index:, partial_arguments_json:)
               return if partial_arguments_json.to_s.empty?
 
+              idx = @tool_ordinals[block_index]
               emit_chunk(delta_envelope({
                                           tool_calls: [{
-                                            index:    block_index,
+                                            index:    idx,
                                             function: { arguments: partial_arguments_json }
                                           }]
                                         }))

--- a/lib/legion/llm/api/client_translators/openai_chat.rb
+++ b/lib/legion/llm/api/client_translators/openai_chat.rb
@@ -300,7 +300,7 @@ module Legion
             def on_tool_call_delta(block_index:, partial_arguments_json:)
               return if partial_arguments_json.to_s.empty?
 
-              idx = @tool_ordinals[block_index]
+              idx = @tool_ordinals[block_index] ||= (@tool_ordinal += 1)
               emit_chunk(delta_envelope({
                                           tool_calls: [{
                                             index:    idx,

--- a/lib/legion/llm/api/client_translators/openai_responses.rb
+++ b/lib/legion/llm/api/client_translators/openai_responses.rb
@@ -18,7 +18,8 @@ module Legion
         #   - parse_request(body, env) -> Canonical::Request (handles
         #     input/instructions/reasoning/tools shapes specific to /v1/responses)
         #   - format_response(canonical_or_pipeline_response) -> Hash with output[]
-        #     containing {thinking, function_call, message} items
+        #     containing {reasoning (phase: 'reasoning' message), server_tool
+        #     function_call/output pairs, actionable function_call, message} items
         #   - format_error(error, status_code:, type:)
         #   - events_emitter(out, ...) -> Events emitter conforming to the
         #     StreamAssembler contract.
@@ -71,7 +72,7 @@ module Legion
           # /v1/responses lane omits reasoning summary content unless the
           # request opts in — without this, codex→openai cells return only
           # the message item (no reasoning), and the e2e validator
-          # reports "reasoning never produced" (P5-final-cells.md B3).
+          # reports "reasoning never produced".
           def ensure_reasoning_summary(body)
             reasoning = body[:reasoning]
             return body unless reasoning.is_a?(Hash)
@@ -94,11 +95,18 @@ module Legion
 
             messages = inference_messages(canonical_request.messages)
 
+            # C7 — header-supplied X-Legion-Model wins; otherwise fall back to
+            # the client-requested body[:model] so routing is never blank when
+            # the caller named a model.
+            routing = (canonical_request.routing || {}).dup
+            client_model = canonical_request.metadata[:client_model]
+            routing[:model] ||= client_model if client_model
+
             Legion::LLM::Inference::Request.build(
               id:              request_id,
               messages:        messages,
               system:          canonical_request.system,
-              routing:         canonical_request.routing,
+              routing:         routing,
               tools:           tool_defs,
               tool_choice:     canonical_request.tool_choice,
               caller:          server_caller,
@@ -341,7 +349,6 @@ module Legion
             end
 
             def on_tool_call_open(block_index:, tool_call:, server_tool:)
-              _ = server_tool
               tc_id = tool_call[:id] || "call_#{SecureRandom.hex(12)}"
               idx = @output_items.length
               item = { id: tc_id, type: 'function_call', name: tool_call[:name].to_s,
@@ -352,7 +359,8 @@ module Legion
                 name:          tool_call[:name].to_s,
                 arguments_str: '',
                 output_index:  idx,
-                args_emitted:  +''
+                args_emitted:  +'',
+                server_tool:   server_tool
               }
               emit('response.output_item.added', {
                      type: 'response.output_item.added', sequence_number: next_seq,
@@ -446,8 +454,12 @@ module Legion
                 @output_items[@msg_index] = completed_item
               end
 
-              has_tool_calls = @pending_tool_calls.any?
-              status = stop_reason == :tool_use || has_tool_calls ? 'requires_action' : 'completed'
+              _ = stop_reason
+              # G24 — server-executed tool calls are non-actionable; only
+              # client-callable tool calls drive `requires_action`.
+              actionable = @pending_tool_calls.values.reject { |tc| tc[:server_tool] }
+              has_tool_calls = actionable.any?
+              status = has_tool_calls ? 'requires_action' : 'completed'
               event = status == 'requires_action' ? 'response.done' : 'response.completed'
               payload = {
                 type: event, sequence_number: next_seq,
@@ -460,7 +472,7 @@ module Legion
               if status == 'requires_action'
                 payload[:response][:action_required] = {
                   type:           'function_calls',
-                  function_calls: @output_items.select { |i| i[:type] == 'function_call' }
+                  function_calls: actionable.map { |tc| @output_items[tc[:output_index]] }
                 }
               end
               emit(event, payload)

--- a/lib/legion/llm/api/debug_formats.rb
+++ b/lib/legion/llm/api/debug_formats.rb
@@ -95,7 +95,9 @@ module Legion
         # on write failure.
         def self.emit_echo_request_sse(out, canonical_request)
           out << "event: legion.debug.echo_request\ndata: #{Legion::JSON.dump(canonical_request.to_h)}\n\n"
-        rescue IOError, Errno::EPIPE
+        rescue IOError, Errno::EPIPE => e
+          handle_exception(e, level: :debug, handled: true,
+                              operation: 'llm.api.debug_formats.emit_echo_request_sse')
           nil
         end
 

--- a/lib/legion/llm/api/namespaces/anthropic/messages.rb
+++ b/lib/legion/llm/api/namespaces/anthropic/messages.rb
@@ -78,7 +78,7 @@ module Legion
                   )
                 rescue Legion::LLM::API::StreamAssembler::StreamClosed
                   # Client disconnected — assembler logged the disconnect; treat as cancellation (G10).
-                rescue IOError, Errno::EPIPE
+                rescue IOError, Errno::EPIPE, *(defined?(Puma::ConnectionError) ? [Puma::ConnectionError] : [])
                   # Client disconnected mid-write before assembler caught it.
                 rescue StandardError => e
                   handle_exception(e, level: :error, handled: false,

--- a/lib/legion/llm/api/namespaces/openai/chat/completions.rb
+++ b/lib/legion/llm/api/namespaces/openai/chat/completions.rb
@@ -87,7 +87,7 @@ module Legion
                       )
                     rescue Legion::LLM::API::StreamAssembler::StreamClosed
                       # Client disconnected — caller treats as cancellation per G10.
-                    rescue IOError, Errno::EPIPE
+                    rescue IOError, Errno::EPIPE, *(defined?(Puma::ConnectionError) ? [Puma::ConnectionError] : [])
                       # Client disconnected mid-write before assembler caught it.
                     rescue StandardError => e
                       handle_exception(e, level: :error, handled: false,

--- a/lib/legion/llm/api/namespaces/openai/responses.rb
+++ b/lib/legion/llm/api/namespaces/openai/responses.rb
@@ -86,7 +86,7 @@ module Legion
                     )
                   rescue Legion::LLM::API::StreamAssembler::StreamClosed
                     # Client disconnected — caller treats as cancellation per G10.
-                  rescue IOError, Errno::EPIPE
+                  rescue IOError, Errno::EPIPE, *(defined?(Puma::ConnectionError) ? [Puma::ConnectionError] : [])
                     # Client disconnected mid-write before assembler caught it.
                   rescue StandardError => e
                     handle_exception(e, level: :error, handled: false,

--- a/lib/legion/llm/api/stream_assembler.rb
+++ b/lib/legion/llm/api/stream_assembler.rb
@@ -275,7 +275,11 @@ module Legion
         end
 
         def handle_text_delta(text)
-          close_thinking_block
+          # NOTE: deliberately NOT closing an open thinking block here — would
+          # silently drop interleaved think→text→think reasoning (DeepSeek-R1
+          # multi-phase). The out-of-order content_block_stop concern only
+          # manifests with emit_thinking_blocks: true (non-default); deferred to
+          # a follow-up that opens a NEW thinking block instead.
           unless @text_block_open
             @text_block_index = @next_block_index
             @next_block_index += 1

--- a/lib/legion/llm/api/stream_assembler.rb
+++ b/lib/legion/llm/api/stream_assembler.rb
@@ -139,7 +139,7 @@ module Legion
           handle_text_delta(adapted.text) if adapted.text && !adapted.text.empty?
         rescue StreamClosed
           raise
-        rescue IOError, Errno::EPIPE => e
+        rescue IOError, Errno::EPIPE, *(defined?(Puma::ConnectionError) ? [Puma::ConnectionError] : []) => e
           mark_closed!(e)
           raise StreamClosed, e.message
         end
@@ -234,9 +234,10 @@ module Legion
 
         # Emitters call this to send a keep-alive ping while a buffered tool
         # call is being assembled (so large tool args don't make the provider
-        # look dead, per G6c). The assembler invokes it from push() when it
-        # detects mid-tool-call gaps; keeping it public lets routes call it
-        # directly during long executor pre-steps too.
+        # look dead, per G6c). Invoked once when a buffered tool-call opens
+        # (handle_tool_call_delta) and may be called directly by routes during
+        # long pre-steps. Interval-based pinging is not yet implemented;
+        # @keep_alive_interval_ms is reserved.
         def keep_alive!
           return if @closed
 
@@ -259,7 +260,7 @@ module Legion
         def guard
           yield
           true
-        rescue IOError, Errno::EPIPE => e
+        rescue IOError, Errno::EPIPE, *(defined?(Puma::ConnectionError) ? [Puma::ConnectionError] : []) => e
           mark_closed!(e)
           false
         end
@@ -274,6 +275,7 @@ module Legion
         end
 
         def handle_text_delta(text)
+          close_thinking_block
           unless @text_block_open
             @text_block_index = @next_block_index
             @next_block_index += 1
@@ -344,8 +346,7 @@ module Legion
           end
 
           # Update accumulated arguments (canonical chunks send the cumulative
-          # arguments hash on every delta — see fixture
-          # canonical_streaming_tool_call_chunks.json A7 note).
+          # arguments hash on every delta).
           state[:arguments] = tool_call[:arguments] || state[:arguments]
           state[:result]    = tool_call[:result]    if tool_call.key?(:result)
 
@@ -576,6 +577,8 @@ module Legion
         private_constant :AdaptedChunk
 
         module ChunkAdapter
+          extend Legion::Logging::Helper
+
           module_function
 
           def normalize(chunk)
@@ -642,7 +645,15 @@ module Legion
           # entry point.
           def safe_call(obj, method)
             obj.public_send(method)
-          rescue Exception # rubocop:disable Lint/RescueException -- isolating provider chunk shape probing
+          rescue NoMethodError
+            nil
+          rescue StandardError => e
+            handle_exception(e, level: :debug, handled: true,
+                                operation: 'llm.api.stream_assembler.safe_call')
+            nil
+          rescue Exception => e # rubocop:disable Lint/RescueException -- isolating provider chunk shape probing
+            raise unless defined?(RSpec) && e.class.name&.start_with?('RSpec::')
+
             nil
           end
 

--- a/lib/legion/llm/call/dispatch.rb
+++ b/lib/legion/llm/call/dispatch.rb
@@ -472,9 +472,13 @@ module Legion
           return {} if arguments.strip.empty?
 
           parsed = Legion::JSON.parse(arguments)
-          parsed.is_a?(Hash) ? parsed : {}
+          return parsed if parsed.is_a?(Hash)
+
+          log.warn("[llm][dispatch] action=parse_arguments non_hash_tool_args type=#{parsed.class}")
+          {}
         rescue StandardError => e
           handle_exception(e, level: :warn, handled: true, operation: 'llm.dispatch.parse_arguments')
+          log.warn("[llm][dispatch] action=parse_arguments parse_failed raw=#{arguments.to_s[0, 200]}")
           {}
         end
 

--- a/lib/legion/llm/capabilities.rb
+++ b/lib/legion/llm/capabilities.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module LLM
     module Capabilities
+      extend Legion::Logging::Helper
+
       ALIASES = {
         function_calling: :tools,
         functions:        :tools,
@@ -17,14 +21,13 @@ module Legion
       module_function
 
       def normalize(capabilities)
-        Array(capabilities).compact.each_with_object([]) do |capability, normalized|
+        Array(capabilities).compact.filter_map do |capability|
           next unless capability.respond_to?(:to_s)
 
           sym = capability.to_s.downcase.strip.tr('-', '_').to_sym
           next if sym.to_s.empty?
 
-          normalized << sym
-          normalized << ALIASES[sym] if ALIASES[sym]
+          ALIASES.fetch(sym, sym)
         end.uniq
       end
 

--- a/lib/legion/llm/discovery.rb
+++ b/lib/legion/llm/discovery.rb
@@ -445,6 +445,7 @@ module Legion
           h['context_length'] = model_entry[:context_length] if model_entry[:context_length]
           h['parameter_count'] = model_entry[:parameter_count] if model_entry[:parameter_count]
           h['size'] = model_entry[:size_bytes] if model_entry[:size_bytes]
+          h['loaded'] = model_entry[:loaded] unless model_entry[:loaded].nil?
           h
         end
 

--- a/lib/legion/llm/errors.rb
+++ b/lib/legion/llm/errors.rb
@@ -60,25 +60,34 @@ module Legion
     class DaemonUnavailableError < LLMError; end
 
     class RoutingUnavailable < LLMError
-      attr_reader :status_code, :code
+      attr_reader :status_code, :code, :reasons
 
-      def initialize(message = 'Routing unavailable', status_code: 503, code: 'routing_unavailable')
+      def initialize(message = 'Routing unavailable', status_code: 503, code: 'routing_unavailable', reasons: [])
         @status_code = status_code
         @code = code
+        @reasons = reasons
         super(message)
       end
+
+      def retryable? = true
     end
 
     class RoutingTooEarly < RoutingUnavailable
-      def initialize(message = 'Routing prerequisites are not confirmed yet')
-        super(message, status_code: 425, code: 'routing_too_early')
+      def initialize(message = 'Routing prerequisites are not confirmed yet', reasons: [])
+        super(message, status_code: 425, code: 'routing_too_early', reasons: reasons)
       end
+
+      def retryable? = true
     end
 
     class RoutingFailedDependency < RoutingUnavailable
-      def initialize(message = 'No provider instance satisfies routing prerequisites')
-        super(message, status_code: 424, code: 'routing_failed_dependency')
+      def initialize(message = 'No provider instance satisfies routing prerequisites', reasons: [])
+        super(message, status_code: 424, code: 'routing_failed_dependency', reasons: reasons)
       end
+
+      # 424 indicates a state prerequisite is unmet (circuit open, model denied, capability
+      # missing) — retrying without a state change is futile. Override the parent's `true`.
+      def retryable? = false
     end
   end
 end

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -86,6 +86,7 @@ module Legion
         ].freeze
 
         REQUEST_PAYLOAD_ERROR_PATTERNS = [
+          /ValidationException/,
           /input_schema/i,
           /tools\.\d+/,
           /messages\.\d+/,

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -89,8 +89,7 @@ module Legion
           /input_schema/i,
           /tools\.\d+/,
           /messages\.\d+/,
-          /Field required/i,
-          /ValidationException/
+          /Field required/i
         ].freeze
 
         CONTEXT_OVERFLOW_ERROR_PATTERNS = [

--- a/lib/legion/llm/inference/executor/escalation.rb
+++ b/lib/legion/llm/inference/executor/escalation.rb
@@ -305,13 +305,29 @@ module Legion
             duration_ms = ((Time.now - start_time) * 1000).round
             handle_exception(err, level: :warn, handled: handled, operation: operation,
                                  provider: resolution.provider, model: resolution.model, duration_ms: duration_ms)
-            if request_payload_error?(err)
+            if bedrock_availability_error?(err)
+              # Bedrock ValidationException whose message indicates the model is not
+              # available in this account/region. Checked BEFORE request_payload_error?
+              # because ValidationException otherwise matches the generic payload-error
+              # pattern and would be misclassified as a daemon-side payload bug.
+              Legion::LLM::Router.health_tracker.deny_model(
+                provider: resolution.provider,
+                model:    resolution.model,
+                instance: resolution.instance,
+                reason:   err.message
+              )
+              Legion::LLM::Router.health_tracker.trip_circuit(
+                provider: resolution.provider,
+                instance: resolution.instance,
+                reason:   err.message
+              )
+            elsif request_payload_error?(err)
               log.error "[llm][escalation] action=request_payload_error provider=#{resolution.provider} " \
                         "instance=#{resolution.instance || 'default'} model=#{resolution.model} " \
                         "error=#{err.message.to_s[0, 500]} daemon_side_payload_bug=true provider_health=false"
             elsif internal_error?(err)
-              # Daemon-internal bug (NoMethodError/NameError/ArgumentError/TypeError/KeyError) —
-              # do NOT report provider health; the provider is not at fault.
+              # Daemon-internal bug (NoMethodError/NameError) — do NOT report
+              # provider health; the provider is not at fault.
               log.error "[llm][escalation] action=daemon_internal_error provider=#{resolution.provider} " \
                         "instance=#{resolution.instance || 'default'} model=#{resolution.model} " \
                         "error=#{err.class}: #{err.message.to_s[0, 500]} daemon_internal_bug=true provider_health=false"
@@ -330,7 +346,11 @@ module Legion
               Legion::LLM::Router.health_tracker.trip_circuit(
                 provider: resolution.provider, instance: resolution.instance, reason: err.message
               )
-            elsif authentication_error?(err) || config_error?(err) || bedrock_availability_error?(err)
+            elsif authentication_error?(err) || config_error?(err) # rubocop:disable Lint/DuplicateBranch
+              # Same action as the bedrock_availability_error? branch, but ORDER
+              # is load-bearing: bedrock must precede request_payload_error?
+              # (ValidationException would otherwise be misclassified there);
+              # auth/config must follow it.
               Legion::LLM::Router.health_tracker.deny_model(
                 provider: resolution.provider,
                 model:    resolution.model,
@@ -393,9 +413,10 @@ module Legion
             chain
           end
 
-          COLD_BOOT_REJECTIONS = %i[discovery_unavailable provider_instance_has_no_models].freeze
+          COLD_BOOT_REJECTIONS = %i[discovery_unavailable provider_instance_has_no_models
+                                    availability_check_error].freeze
           FAILED_DEPENDENCY_REJECTIONS = %i[circuit_open model_denied model_not_offered context_too_small
-                                            missing_capability availability_check_error].freeze
+                                            missing_capability instance_unresolved].freeze
 
           # Determine the appropriate typed error when the escalation chain is empty.
           # Uses the rejection reasons threaded through from availability filtering to
@@ -503,11 +524,32 @@ module Legion
                                       model: @resolved_model, offering_id: @resolved_offering_id,
                                       status: 'provider_error')
             emit_error_audit(error, status: status, provider: provider, model: model)
+            if bedrock_availability_error?(error)
+              Legion::LLM::Router.health_tracker.deny_model(
+                provider: provider,
+                model:    model,
+                instance: instance,
+                reason:   error.message
+              )
+              Legion::LLM::Router.health_tracker.trip_circuit(
+                provider: provider,
+                instance: instance,
+                reason:   error.message
+              )
+              return
+            end
             return if request_payload_error?(error)
+
+            if internal_error?(error)
+              log.error "[llm][escalation] action=daemon_internal_error provider=#{provider} " \
+                        "instance=#{instance || 'default'} model=#{model} " \
+                        "error=#{error.class}: #{error.message.to_s[0, 500]} daemon_internal_bug=true provider_health=false"
+              return
+            end
             return if context_overflow_error?(error)
             return if client_stream_error?(error)
 
-            if authentication_error?(error) || config_error?(error) || bedrock_availability_error?(error)
+            if authentication_error?(error) || config_error?(error)
               Legion::LLM::Router.health_tracker.deny_model(
                 provider: provider,
                 model:    model,
@@ -689,9 +731,11 @@ module Legion
           # itself, not in the provider. These must never be reported as
           # provider :error health signals (which would trip a circuit and
           # blame an innocent backend for our own NoMethodError).
+          # ArgumentError/TypeError/KeyError can originate in provider SDK decode
+          # paths and should accumulate :error signals; only NoMethodError/NameError
+          # reliably indicate daemon code bugs.
           def internal_error?(err)
-            err.is_a?(NoMethodError) || err.is_a?(NameError) || err.is_a?(ArgumentError) ||
-              err.is_a?(TypeError) || err.is_a?(KeyError)
+            err.is_a?(NoMethodError) || err.is_a?(NameError)
           end
 
           # Bedrock ValidationException messages that indicate the model is not
@@ -700,7 +744,7 @@ module Legion
           # (treat like config_error?) so the model is excluded rather than
           # silently logged.
           def bedrock_availability_error?(err)
-            err.message.to_s.match?(/model identifier is invalid|not enabled in this region|on-demand throughput|model.*does not support/i)
+            err.message.to_s.match?(/model identifier is invalid|not enabled in this region|on-demand throughput|inference profile/i)
           end
 
           def config_error?(err)

--- a/lib/legion/llm/inference/executor/escalation.rb
+++ b/lib/legion/llm/inference/executor/escalation.rb
@@ -6,7 +6,8 @@ module Legion
   module LLM
     module Inference
       class Executor
-        # Escalation-area methods extracted from Executor verbatim (P4b §1.5, refactor-under-green).
+        # Escalation-area methods extracted from Executor (P4b); since extended
+        # for instance-aware failover (0.12.35).
         # Owns the provider-call lifecycle (single + escalating, sync + stream + responses-API),
         # error/retry classification, and the corresponding audit/metering emission.
         module Escalation
@@ -62,7 +63,8 @@ module Legion
             primary_tier = @escalation_chain.primary&.tier
 
             if chain.empty?
-              err = routing_empty_chain_error
+              reasons = chain.respond_to?(:rejection_reasons) ? Array(chain.rejection_reasons) : []
+              err = routing_empty_chain_error(reasons)
               log.warn "[llm][escalation] action=empty_chain reason=#{err.class.name}"
               emit_error_audit(err, status: 'no_available_provider')
               raise err
@@ -307,6 +309,12 @@ module Legion
               log.error "[llm][escalation] action=request_payload_error provider=#{resolution.provider} " \
                         "instance=#{resolution.instance || 'default'} model=#{resolution.model} " \
                         "error=#{err.message.to_s[0, 500]} daemon_side_payload_bug=true provider_health=false"
+            elsif internal_error?(err)
+              # Daemon-internal bug (NoMethodError/NameError/ArgumentError/TypeError/KeyError) —
+              # do NOT report provider health; the provider is not at fault.
+              log.error "[llm][escalation] action=daemon_internal_error provider=#{resolution.provider} " \
+                        "instance=#{resolution.instance || 'default'} model=#{resolution.model} " \
+                        "error=#{err.class}: #{err.message.to_s[0, 500]} daemon_internal_bug=true provider_health=false"
             elsif account_specific_error?(err)
               # Account-scoped failure (credit balance, payment, quota). It is
               # deterministic — it will fail every call until the operator tops up —
@@ -322,7 +330,7 @@ module Legion
               Legion::LLM::Router.health_tracker.trip_circuit(
                 provider: resolution.provider, instance: resolution.instance, reason: err.message
               )
-            elsif authentication_error?(err) || config_error?(err)
+            elsif authentication_error?(err) || config_error?(err) || bedrock_availability_error?(err)
               Legion::LLM::Router.health_tracker.deny_model(
                 provider: resolution.provider,
                 model:    resolution.model,
@@ -385,16 +393,20 @@ module Legion
             chain
           end
 
+          COLD_BOOT_REJECTIONS = %i[discovery_unavailable provider_instance_has_no_models].freeze
+          FAILED_DEPENDENCY_REJECTIONS = %i[circuit_open model_denied model_not_offered context_too_small
+                                            missing_capability availability_check_error].freeze
+
           # Determine the appropriate typed error when the escalation chain is empty.
-          # Uses the last rejection reasons from availability filtering to distinguish
-          # between "too early" (prerequisites not yet confirmed) and "failed dependency"
-          # (no provider can satisfy the requirements).
-          def routing_empty_chain_error
-            reasons = Legion::LLM::Router::Availability.last_rejection_reasons
-            if reasons.include?(:capability_unconfirmed)
-              RoutingTooEarly.new
-            elsif reasons.any?
-              RoutingFailedDependency.new
+          # Uses the rejection reasons threaded through from availability filtering to
+          # distinguish between "too early" (prerequisites not yet confirmed) and
+          # "failed dependency" (no provider can satisfy the requirements).
+          def routing_empty_chain_error(reasons)
+            reason_syms = Array(reasons).map { |r| r.is_a?(Hash) ? r[:reason] : r }.compact
+            if reason_syms.any? { |r| COLD_BOOT_REJECTIONS.include?(r) }
+              RoutingTooEarly.new(reasons: reasons)
+            elsif reason_syms.any? { |r| FAILED_DEPENDENCY_REJECTIONS.include?(r) }
+              RoutingFailedDependency.new(reasons: reasons)
             else
               EscalationExhausted.new('No available providers after routing availability filtering')
             end
@@ -476,7 +488,7 @@ module Legion
 
           def record_provider_response
             duration_ms = ((@timestamps[:provider_end] - @timestamps[:provider_start]) * 1000).to_i
-            report_provider_health(:success, duration_ms) if @resolved_offering_id
+            report_provider_health(:success, duration_ms)
             log.debug("[pipeline][provider] action=response_received provider=#{@resolved_provider} model=#{@resolved_model} duration_ms=#{duration_ms}")
             @timeline.record(
               category: :provider, key: 'provider:response_received',
@@ -495,7 +507,7 @@ module Legion
             return if context_overflow_error?(error)
             return if client_stream_error?(error)
 
-            if authentication_error?(error) || config_error?(error)
+            if authentication_error?(error) || config_error?(error) || bedrock_availability_error?(error)
               Legion::LLM::Router.health_tracker.deny_model(
                 provider: provider,
                 model:    model,
@@ -671,6 +683,24 @@ module Legion
             name = err.class.name.to_s
             msg = err.message.to_s
             REQUEST_PAYLOAD_ERROR_PATTERNS.any? { |pat| pat.match?(name) || pat.match?(msg) }
+          end
+
+          # Daemon-internal Ruby exceptions — bugs in the executor/dispatch path
+          # itself, not in the provider. These must never be reported as
+          # provider :error health signals (which would trip a circuit and
+          # blame an innocent backend for our own NoMethodError).
+          def internal_error?(err)
+            err.is_a?(NoMethodError) || err.is_a?(NameError) || err.is_a?(ArgumentError) ||
+              err.is_a?(TypeError) || err.is_a?(KeyError)
+          end
+
+          # Bedrock ValidationException messages that indicate the model is not
+          # available in this account/region — an availability/config outcome,
+          # not a daemon-side request payload bug. Routed to the deny/trip path
+          # (treat like config_error?) so the model is excluded rather than
+          # silently logged.
+          def bedrock_availability_error?(err)
+            err.message.to_s.match?(/model identifier is invalid|not enabled in this region|on-demand throughput|model.*does not support/i)
           end
 
           def config_error?(err)

--- a/lib/legion/llm/inference/executor/routing.rb
+++ b/lib/legion/llm/inference/executor/routing.rb
@@ -39,14 +39,24 @@ module Legion
           def step_tier_assignment
             gaia_hint = @enrichments['gaia:routing_hint']
             classification = @enrichments['classification:scan']
-            assignment = Steps::TierAssigner.assign(
-              caller:          @request.caller,
-              classification:  classification,
-              priority:        @request.priority,
-              gaia_hint:       gaia_hint,
-              existing_tier:   @request.extra[:tier],
-              existing_intent: @request.extra[:intent]
-            )
+            begin
+              assignment = Steps::TierAssigner.assign(
+                caller:          @request.caller,
+                classification:  classification,
+                priority:        @request.priority,
+                gaia_hint:       gaia_hint,
+                existing_tier:   @request.extra[:tier],
+                existing_intent: @request.extra[:intent]
+              )
+            rescue StandardError => e
+              # Fail-closed: forced tier assignments carry privacy/security
+              # constraints (see apply_proactive_tier_assignment). Whether this
+              # assignment would have been forced is not determinable when the
+              # assigner itself raised, so re-raise rather than silently continue
+              # with a request that may violate a privacy tier constraint.
+              handle_exception(e, level: :error, operation: 'llm.pipeline.step_tier_assignment')
+              raise
+            end
             return unless assignment
 
             @proactive_tier_assignment = assignment
@@ -63,14 +73,6 @@ module Legion
               detail: "tier=#{assignment[:tier]} assigned by #{assignment[:source]}",
               from: 'tier_assigner', to: 'pipeline'
             )
-          rescue StandardError => e
-            # Fail-closed: forced tier assignments carry privacy/security
-            # constraints (see apply_proactive_tier_assignment). Whether this
-            # assignment would have been forced is not determinable when the
-            # assigner itself raised, so re-raise rather than silently continue
-            # with a request that may violate a privacy tier constraint.
-            handle_exception(e, level: :error, operation: 'llm.pipeline.step_tier_assignment')
-            raise
           end
 
           def step_routing

--- a/lib/legion/llm/inference/executor/routing.rb
+++ b/lib/legion/llm/inference/executor/routing.rb
@@ -6,9 +6,9 @@ module Legion
   module LLM
     module Inference
       class Executor
-        # Routing-area methods extracted from Executor verbatim (P4b §1.5, refactor-under-green).
-        # Operates on Executor instance state; see P4b-decomposition-embed.md §1.1 for the ivar
-        # contract this mixin reads/writes.
+        # Routing-area methods extracted from Executor (P4b); since extended for
+        # instance-aware failover (0.12.35). Reads/writes Executor instance
+        # state; see ivar usage below.
         module Routing
           def normalize_offering_metadata(value)
             return {} unless value.is_a?(Hash)
@@ -64,8 +64,13 @@ module Legion
               from: 'tier_assigner', to: 'pipeline'
             )
           rescue StandardError => e
-            @warnings << "tier assignment error: #{e.message}"
-            handle_exception(e, level: :warn, operation: 'llm.pipeline.step_tier_assignment')
+            # Fail-closed: forced tier assignments carry privacy/security
+            # constraints (see apply_proactive_tier_assignment). Whether this
+            # assignment would have been forced is not determinable when the
+            # assigner itself raised, so re-raise rather than silently continue
+            # with a request that may violate a privacy tier constraint.
+            handle_exception(e, level: :error, operation: 'llm.pipeline.step_tier_assignment')
+            raise
           end
 
           def step_routing

--- a/lib/legion/llm/inference/route_attempts.rb
+++ b/lib/legion/llm/inference/route_attempts.rb
@@ -132,7 +132,7 @@ module Legion
           context_window = final_context_window
           return unless context_window.positive?
 
-          threshold = (context_window * 0.90).to_i
+          threshold = (context_window * Legion::LLM::Router::Availability.context_headroom).to_i
           estimated_tokens = final_dispatch_token_estimate(messages, dispatch_options)
           return if estimated_tokens <= threshold
 

--- a/lib/legion/llm/router.rb
+++ b/lib/legion/llm/router.rb
@@ -45,6 +45,14 @@ module Legion
 
       OLLAMA_MODEL_PATTERN = %r{[:/]}
 
+      # Carry availability rejection reasons on the chain instance so the
+      # executor can raise a typed routing error without reading thread-unsafe
+      # module state (C1). Additive reopen — EscalationChain itself is defined
+      # in router/escalation/chain.rb.
+      class EscalationChain
+        attr_accessor :rejection_reasons
+      end
+
       @auto_rules = []
       @auto_rules_populated = false
 
@@ -118,7 +126,7 @@ module Legion
 
           merged = merge_defaults(intent)
           rules = load_rules
-          candidates = select_candidates(rules, merged, exclude: exclude, estimated_tokens: estimated_tokens)
+          candidates, trace = select_candidates(rules, merged, exclude: exclude, estimated_tokens: estimated_tokens)
           best = pick_best(candidates, intent: merged, hints: { tier: tier, provider: provider, model: model })
           resolution = best&.to_resolution
 
@@ -141,7 +149,7 @@ module Legion
 
           # If no rules matched (or hint mismatch), fall back to explicit resolution from hints, then arbitrage.
           unless resolution
-            trace_info = (@last_candidate_trace || {}).reject { |_, v| v.zero? }
+            trace_info = (trace || {}).reject { |_, v| v.zero? }
             log.warn "[llm][router] action=resolve.no_rules_matched intent=#{merged} candidates_evaluated=#{rules.size} " \
                      "rejections=#{trace_info}"
             resolution = explicit_resolution(tier, provider, model, instance)
@@ -160,7 +168,10 @@ module Legion
                               exclude: exclude, allow_default_fallback: allow_default_fallback,
                               estimated_tokens: estimated_tokens)
           else
-            chain_from_defaults(model, provider, max, hints: { tier: tier, instance: instance }, allow_default_fallback: allow_default_fallback)
+            req_caps = intent ? required_capabilities(intent) : []
+            chain_from_defaults(model, provider, max, hints: { tier: tier, instance: instance },
+                                allow_default_fallback: allow_default_fallback,
+                                estimated_tokens: estimated_tokens, required_capabilities: req_caps)
           end
         end
 
@@ -290,10 +301,12 @@ module Legion
             primary_tier:     tier
           )
           resolutions = ([primary] + fallbacks).compact.uniq { |r| [r.provider, r.instance, r.model] }
-          resolutions = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
-                                                              required_capabilities: required_capabilities)
+          resolutions, reasons = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
+                                                                       required_capabilities: required_capabilities)
           max = max_attempts || escalation_max_attempts
-          EscalationChain.new(resolutions: resolutions, max_attempts: max)
+          chain = EscalationChain.new(resolutions: resolutions, max_attempts: max)
+          chain.rejection_reasons = reasons
+          chain
         end
 
         def build_fallback_resolutions(exclude_provider: nil, exclude_instance: nil, primary_tier: nil)
@@ -417,24 +430,18 @@ module Legion
         end
 
         def filter_chain_resolutions(resolutions, estimated_tokens:, required_capabilities:)
-          filtered = Availability.filter_resolutions(
+          filtered, reasons = Availability.filter_resolutions(
             resolutions,
             estimated_tokens:      estimated_tokens,
             required_capabilities: required_capabilities
           )
-          return filtered unless filtered.empty? && resolutions.any?
+          return [filtered, reasons] unless filtered.empty? && resolutions.any?
 
-          reasons = resolutions.filter_map do |resolution|
-            Availability.rejection_reason(
-              resolution,
-              estimated_tokens:      estimated_tokens,
-              required_capabilities: required_capabilities
-            )
-          end
-          return filtered unless reasons.any? && reasons.all? { |reason| reason == :provider_instance_has_no_models }
+          reason_syms = reasons.map { |r| r[:reason] }
+          return [filtered, reasons] unless reason_syms.any? && reason_syms.all? { |reason| reason == :provider_instance_has_no_models }
 
           log.warn "[llm][router] action=availability.empty_catalog_preserve_chain candidates=#{resolutions.size}"
-          resolutions
+          [resolutions, reasons]
         end
 
         def merge_defaults(intent)
@@ -443,6 +450,10 @@ module Legion
                      .each_with_object({}) do |(k, v), memo|
                        memo[k] = v.respond_to?(:to_sym) ? v.to_sym : v
                      end
+          if defaults.key?(:capability)
+            log.warn '[llm][router] routing.default_intent contains deprecated :capability key — ignoring; use :effort instead'
+            defaults = defaults.except(:capability)
+          end
 
           raw_intent = intent&.transform_keys(&:to_sym) || {}
           merged = defaults.merge(raw_intent)
@@ -571,15 +582,19 @@ module Legion
               r.provider == primary.provider && r.instance == primary.instance
             end
             resolutions = ([primary] + fallbacks).uniq { |r| [r.provider, r.instance, r.model] }
-            resolutions = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
-                                                                required_capabilities: required_capabilities)
-            return EscalationChain.new(resolutions: resolutions, max_attempts: max)
+            resolutions, reasons = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
+                                                                         required_capabilities: required_capabilities)
+            chain = EscalationChain.new(resolutions: resolutions, max_attempts: max)
+            chain.rejection_reasons = reasons
+            return chain
           end
 
+          all_reasons = []
           resolutions = enabled_provider_chain
           if resolutions.any?
-            resolutions = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
-                                                                required_capabilities: required_capabilities)
+            resolutions, reasons = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
+                                                                         required_capabilities: required_capabilities)
+            all_reasons.concat(reasons)
           end
           if resolutions.empty? && allow_default_fallback
             p = Legion::Settings[:llm][:default_provider]&.to_sym ||
@@ -588,10 +603,13 @@ module Legion
                                           provider: p,
                                           model:    Legion::Settings[:llm][:default_model] ||
                                                     Legion::Settings[:llm][:routing][:last_resort_model])]
-            resolutions = filter_chain_resolutions(last_resort, estimated_tokens:      estimated_tokens,
-                                                                required_capabilities: required_capabilities)
+            resolutions, reasons = filter_chain_resolutions(last_resort, estimated_tokens:      estimated_tokens,
+                                                                         required_capabilities: required_capabilities)
+            all_reasons.concat(reasons)
           end
-          EscalationChain.new(resolutions: resolutions, max_attempts: max)
+          chain = EscalationChain.new(resolutions: resolutions, max_attempts: max)
+          chain.rejection_reasons = all_reasons
+          chain
         end
 
         def enabled_provider_chain
@@ -681,18 +699,21 @@ module Legion
           merged     = intent ? merge_defaults(intent) : {}
           req_caps   = required_capabilities(merged)
           rules      = load_rules
-          candidates = select_candidates(rules, merged, exclude: exclude, estimated_tokens: estimated_tokens)
+          candidates, _trace = select_candidates(rules, merged, exclude: exclude, estimated_tokens: estimated_tokens)
           sorted = candidates.sort_by { |r| -effective_priority(r, intent: merged, hints: hints) }
           resolutions = sorted.map(&:to_resolution)
           resolutions = build_fallback_chain(sorted.first, sorted, resolutions) if sorted.first&.fallback
           resolutions = resolutions.uniq { |r| [r.provider, r.instance, r.model] }
           resolutions = prepend_hinted_provider(resolutions, hints)
-          resolutions = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
-                                                              required_capabilities: req_caps)
+          all_reasons = []
+          resolutions, reasons = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
+                                                                       required_capabilities: req_caps)
+          all_reasons.concat(reasons)
           resolutions = enabled_provider_chain if resolutions.empty?
           if resolutions.any?
-            resolutions = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
-                                                                required_capabilities: req_caps)
+            resolutions, reasons = filter_chain_resolutions(resolutions, estimated_tokens:      estimated_tokens,
+                                                                         required_capabilities: req_caps)
+            all_reasons.concat(reasons)
           end
           if resolutions.empty? && allow_default_fallback
             p = Legion::Settings[:llm][:default_provider]&.to_sym ||
@@ -701,10 +722,13 @@ module Legion
                                           provider: p,
                                           model:    Legion::Settings[:llm][:default_model] ||
                                                     Legion::Settings[:llm][:routing][:last_resort_model])]
-            resolutions = filter_chain_resolutions(last_resort, estimated_tokens:      estimated_tokens,
-                                                                required_capabilities: req_caps)
+            resolutions, reasons = filter_chain_resolutions(last_resort, estimated_tokens:      estimated_tokens,
+                                                                         required_capabilities: req_caps)
+            all_reasons.concat(reasons)
           end
-          EscalationChain.new(resolutions: resolutions, max_attempts: max)
+          chain = EscalationChain.new(resolutions: resolutions, max_attempts: max)
+          chain.rejection_reasons = all_reasons
+          chain
         end
 
         def build_fallback_chain(primary_rule, candidates, default_chain)

--- a/lib/legion/llm/router/availability.rb
+++ b/lib/legion/llm/router/availability.rb
@@ -14,15 +14,16 @@ module Legion
 
         def filter_resolutions(resolutions, estimated_tokens: nil, required_capabilities: [])
           req_caps = Array(required_capabilities)
-          @last_rejection_reasons = []
-          resolutions.filter_map do |resolution|
+          reasons = []
+          filtered = resolutions.filter_map do |resolution|
             reason = rejection_reason(
               resolution,
               estimated_tokens:      estimated_tokens,
               required_capabilities: req_caps
             )
             if reason
-              @last_rejection_reasons << reason
+              reasons << { provider: resolution.provider, instance: resolution.instance,
+                           model: resolution.model, reason: reason }
               detail = if reason == :missing_capability
                          caps = available_capabilities(resolution)
                          missing = Capabilities.normalize(req_caps) - Capabilities.normalize(caps)
@@ -37,10 +38,12 @@ module Legion
             end
             resolution
           end
+          [filtered, reasons]
         end
 
+        # DEPRECATED: use the second return value of filter_resolutions
         def last_rejection_reasons
-          @last_rejection_reasons || []
+          []
         end
 
         def rejection_reason(resolution, estimated_tokens: nil, required_capabilities: [])
@@ -96,9 +99,9 @@ module Legion
 
           nil
         rescue StandardError => e
-          handle_exception(e, level: :warn, handled: true, operation: 'router.availability',
+          handle_exception(e, level: :error, handled: true, operation: 'llm.router.availability.rejection_reason',
                               provider: resolution.provider)
-          nil
+          :availability_check_error
         end
 
         def inventory_offerings_for(resolution)
@@ -108,7 +111,7 @@ module Legion
           # A model being offered by ANY instance of the provider confirms availability.
           Inventory.offerings(provider: resolution.provider)
         rescue StandardError => e
-          handle_exception(e, level: :debug, handled: true, operation: 'router.availability.inventory_lookup')
+          handle_exception(e, level: :warn, handled: true, operation: 'router.availability.inventory_lookup')
           nil
         end
 

--- a/lib/legion/llm/router/availability.rb
+++ b/lib/legion/llm/router/availability.rb
@@ -2,6 +2,7 @@
 
 require 'legion/logging/helper'
 require_relative '../capabilities'
+require_relative '../deprecation'
 require_relative '../inventory'
 
 module Legion
@@ -43,6 +44,10 @@ module Legion
 
         # DEPRECATED: use the second return value of filter_resolutions
         def last_rejection_reasons
+          Legion::LLM::Deprecation.warn_once(
+            'Router::Availability.last_rejection_reasons',
+            replacement: 'the second return value of filter_resolutions'
+          )
           []
         end
 

--- a/lib/legion/llm/router/candidates.rb
+++ b/lib/legion/llm/router/candidates.rb
@@ -5,14 +5,15 @@ require 'legion/logging/helper'
 module Legion
   module LLM
     module Router
-      # Candidate selection, exclusion filters, and scoring extracted verbatim
-      # from Router (NxN G14 3c). Mixed into the Router singleton via `extend`,
-      # so every method keeps the same `self` (the Router module), the same
-      # private visibility, the same access to Router constants (EFFORT_RANK),
-      # to sibling helpers that stay on Router (tier_available?, tier_rank,
-      # tier_priority, health_tracker, discovery_enabled?, required_capabilities,
-      # normalize_capabilities, normalize_effort, external_tier?), and to the
-      # @last_candidate_trace ivar. No behavior change.
+      # Candidate selection, exclusion filters, and scoring. Extracted from
+      # Router (G14 P4). Originally a verbatim move; since extended with
+      # effort/loaded scoring (0.12.20) and dominant hint weighting (+50,000,
+      # 0.12.30). Mixed into the Router singleton via `extend`, so every method
+      # keeps the same `self` (the Router module), the same private visibility,
+      # the same access to Router constants (EFFORT_RANK), and to sibling
+      # helpers that stay on Router (tier_available?, tier_rank, tier_priority,
+      # health_tracker, discovery_enabled?, required_capabilities,
+      # normalize_capabilities, normalize_effort, external_tier?).
       module Candidates
         private
 
@@ -94,10 +95,9 @@ module Legion
           final = not_denied.select { |r| tier_available?(r.target[:tier] || r.target['tier']) }
           trace[:tier_unavailable] = not_denied.size - final.size
 
-          @last_candidate_trace = trace
           log.debug "[llm][router] action=select_candidates.done candidates_remaining=#{final.size} started_with=#{rules.size}"
 
-          final
+          [final, trace]
         end
 
         # Reject rules whose model's context_length is too small for the estimated token count.
@@ -106,7 +106,7 @@ module Legion
           context_length = rule.target[:context_length] || rule.target['context_length']
           return false unless context_length&.to_i&.positive?
 
-          threshold = (context_length.to_i * 0.90).to_i
+          threshold = (context_length.to_i * Availability.context_headroom).to_i
           if estimated_tokens > threshold
             log.debug "[llm][router] action=excluded_by_context_window model=#{rule.target[:model]} " \
                       "context_length=#{context_length} estimated_tokens=#{estimated_tokens} threshold=#{threshold}"
@@ -232,7 +232,6 @@ module Legion
         # Score bonus when a rule's target matches caller-provided hints.
         # Each matching hint adds +50,000 to the priority, so header preferences
         # dominate normal scoring without converting preferences into constraints.
-        # rule priority, health, or cost considerations.
         def hint_matching_bonus(rule, hints)
           return 0 if hints.nil? || hints.empty?
 

--- a/lib/legion/llm/router/health_tracker.rb
+++ b/lib/legion/llm/router/health_tracker.rb
@@ -195,8 +195,10 @@ module Legion
         # Returns all tracked instance keys for a given provider (keys matching "provider/...")
         def known_instances(provider)
           prefix = "#{provider}/"
-          all_keys = (@circuits.keys + @latency_window.keys).uniq
-          all_keys.select { |k| k.is_a?(String) && k.start_with?(prefix) }
+          @mutex.synchronize do
+            all_keys = (@circuits.keys + @latency_window.keys).uniq
+            all_keys.select { |k| k.is_a?(String) && k.start_with?(prefix) }
+          end
         end
 
         def build_payload(provider:, instance:, key:, offering_id:, signal:, value:, metadata:)

--- a/lib/legion/llm/tools/dispatcher.rb
+++ b/lib/legion/llm/tools/dispatcher.rb
@@ -219,7 +219,8 @@ module Legion
         def tool_error_log_chars
           configured = Legion::Settings[:llm][:tool_error_log_chars].to_i
           configured.positive? ? configured : 500
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, handled: true, operation: 'llm.tools.tool_error_log_chars')
           500
         end
       end

--- a/lib/legion/llm/tools/special.rb
+++ b/lib/legion/llm/tools/special.rb
@@ -412,7 +412,8 @@ module Legion
         def tool_error_log_chars
           configured = Legion::Settings[:llm][:tool_error_log_chars].to_i
           configured.positive? ? configured : 500
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, handled: true, operation: 'llm.tools.tool_error_log_chars')
           500
         end
       end

--- a/spec/legion/llm/api/client_translators/routing_headers_spec.rb
+++ b/spec/legion/llm/api/client_translators/routing_headers_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'client translator Legion routing headers' do
     }
   end
 
-  shared_examples 'a translator that ignores the protocol model for routing' do |body|
+  shared_examples 'a translator that prefers X-Legion-Model header over body model for routing' do |body|
     it 'routes only from X-Legion-* headers and preserves the client body model as metadata' do
       canonical_request = translator.parse_request(body, env)
       inference_request = translator.build_inference_request(
@@ -52,26 +52,37 @@ RSpec.describe 'client translator Legion routing headers' do
         provider: true, instance: true, tier: true
       )
     end
+
+    it 'leaves routing[:model] nil when the body model is the legionio sentinel and X-Legion-Model is absent' do
+      canonical_request = translator.parse_request(body.merge(model: 'legionio'), env.except('HTTP_X_LEGION_MODEL'))
+      inference_request = translator.build_inference_request(
+        canonical_request,
+        request_id:    'req_test',
+        server_caller: { source: 'spec' }
+      )
+
+      expect(inference_request.routing[:model]).to be_nil
+    end
   end
 
   describe Legion::LLM::API::ClientTranslators::OpenAIResponses do
     let(:translator) { described_class.new }
 
-    include_examples 'a translator that ignores the protocol model for routing',
+    include_examples 'a translator that prefers X-Legion-Model header over body model for routing',
                      { model: 'client-body-model', input: 'hello' }
   end
 
   describe Legion::LLM::API::ClientTranslators::OpenAIChat do
     let(:translator) { described_class.new }
 
-    include_examples 'a translator that ignores the protocol model for routing',
+    include_examples 'a translator that prefers X-Legion-Model header over body model for routing',
                      { model: 'client-body-model', messages: [{ role: 'user', content: 'hello' }] }
   end
 
   describe Legion::LLM::API::ClientTranslators::AnthropicMessages do
     let(:translator) { described_class.new }
 
-    include_examples 'a translator that ignores the protocol model for routing',
+    include_examples 'a translator that prefers X-Legion-Model header over body model for routing',
                      { model: 'client-body-model', max_tokens: 1024, messages: [{ role: 'user', content: 'hello' }] }
   end
 end

--- a/spec/legion/llm/api/client_translators/routing_headers_spec.rb
+++ b/spec/legion/llm/api/client_translators/routing_headers_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'client translator Legion routing headers' do
       expect(canonical_request.routing).to eq(
         model: 'gpt-5.4-mini', provider: 'openai', instance: 'env'
       )
-      expect(canonical_request.metadata[:client_model]).to eq('legionio')
+      expect(canonical_request.metadata[:client_model]).to eq('client-body-model')
       expect(inference_request.routing).to eq(
         model: 'gpt-5.4-mini', provider: 'openai', instance: 'env'
       )
@@ -37,7 +37,7 @@ RSpec.describe 'client translator Legion routing headers' do
       )
     end
 
-    it 'does not use body model as routing input when X-Legion-Model is absent' do
+    it 'falls back to the body model for routing[:model] when X-Legion-Model is absent' do
       canonical_request = translator.parse_request(body, env.except('HTTP_X_LEGION_MODEL'))
       inference_request = translator.build_inference_request(
         canonical_request,
@@ -46,7 +46,7 @@ RSpec.describe 'client translator Legion routing headers' do
       )
 
       expect(canonical_request.routing).to eq(provider: 'openai', instance: 'env')
-      expect(inference_request.routing).to eq(provider: 'openai', instance: 'env')
+      expect(inference_request.routing).to eq(model: 'client-body-model', provider: 'openai', instance: 'env')
       expect(inference_request.extra[:auto_route]).to be_nil
       expect(inference_request.extra[:routing_explicit]).to eq(
         provider: true, instance: true, tier: true
@@ -58,20 +58,20 @@ RSpec.describe 'client translator Legion routing headers' do
     let(:translator) { described_class.new }
 
     include_examples 'a translator that ignores the protocol model for routing',
-                     { model: 'legionio', input: 'hello' }
+                     { model: 'client-body-model', input: 'hello' }
   end
 
   describe Legion::LLM::API::ClientTranslators::OpenAIChat do
     let(:translator) { described_class.new }
 
     include_examples 'a translator that ignores the protocol model for routing',
-                     { model: 'legionio', messages: [{ role: 'user', content: 'hello' }] }
+                     { model: 'client-body-model', messages: [{ role: 'user', content: 'hello' }] }
   end
 
   describe Legion::LLM::API::ClientTranslators::AnthropicMessages do
     let(:translator) { described_class.new }
 
     include_examples 'a translator that ignores the protocol model for routing',
-                     { model: 'legionio', max_tokens: 1024, messages: [{ role: 'user', content: 'hello' }] }
+                     { model: 'client-body-model', max_tokens: 1024, messages: [{ role: 'user', content: 'hello' }] }
   end
 end

--- a/spec/legion/llm/api/matrix/execution_proxy_matrix_spec.rb
+++ b/spec/legion/llm/api/matrix/execution_proxy_matrix_spec.rb
@@ -163,13 +163,10 @@ RSpec.describe '[matrix] execution-proxy path × FakeProvider', type: :request d
   describe '/v1/messages — server-side LegionIO tool execution' do
     it 'surfaces server_tool_use+server_tool_result and provider sees the tool result on next turn' do
       received_args = nil
-      stub = MatrixHelper::FakeLegionEcho.singleton_class.prepend(Module.new do
-        define_method(:call) do |**args|
-          received_args = args
-          super(**args)
-        end
-      end)
-      _ = stub
+      allow(MatrixHelper::FakeLegionEcho).to receive(:call).and_wrap_original do |orig, **args|
+        received_args = args
+        orig.call(**args)
+      end
 
       FakeProvider.with_scenario(:server_tool_legion) do
         post '/v1/messages',

--- a/spec/legion/llm/capabilities_spec.rb
+++ b/spec/legion/llm/capabilities_spec.rb
@@ -4,14 +4,14 @@ require 'spec_helper'
 
 RSpec.describe Legion::LLM::Capabilities do
   describe '.normalize' do
-    it 'normalizes and adds aliases' do
+    it 'replaces aliases with their canonical capability' do
       result = described_class.normalize(%i[function_calling tool_use stream])
-      expect(result).to include(:function_calling, :tools, :tool_use, :stream, :streaming)
+      expect(result).to contain_exactly(:tools, :streaming)
     end
 
     it 'handles string inputs' do
       result = described_class.normalize(%w[Function_Calling Stream])
-      expect(result).to include(:function_calling, :tools, :stream, :streaming)
+      expect(result).to contain_exactly(:tools, :streaming)
     end
 
     it 'returns empty for nil' do
@@ -22,6 +22,10 @@ RSpec.describe Legion::LLM::Capabilities do
   describe '.include_all?' do
     it 'matches via aliases' do
       expect(described_class.include_all?(%i[completion function_calling], [:tools])).to be true
+    end
+
+    it 'matches when required uses an alias and available uses the canonical' do
+      expect(described_class.include_all?(%i[tools], [:function_calling])).to be true
     end
 
     it 'returns false when capability is absent' do
@@ -40,7 +44,7 @@ RSpec.describe Legion::LLM::Capabilities do
   describe '.merge' do
     it 'merges multiple capability sets with dedup' do
       result = described_class.merge(%i[completion function_calling], %i[streaming tool_use])
-      expect(result).to include(:completion, :function_calling, :tools, :streaming, :tool_use)
+      expect(result).to include(:completion, :tools, :streaming)
       expect(result.uniq).to eq(result)
     end
   end

--- a/spec/legion/llm/errors_spec.rb
+++ b/spec/legion/llm/errors_spec.rb
@@ -60,6 +60,43 @@ RSpec.describe 'Legion::LLM error hierarchy' do
     end
   end
 
+  describe Legion::LLM::RoutingUnavailable do
+    it 'is retryable' do
+      expect(described_class.new).to be_retryable
+    end
+
+    it 'carries reasons through the kwarg' do
+      reasons = [{ provider: :vllm, instance: :h200, model: 'qwen', reason: :circuit_open }]
+      expect(described_class.new(reasons: reasons).reasons).to eq(reasons)
+    end
+  end
+
+  describe Legion::LLM::RoutingTooEarly do
+    it 'is retryable' do
+      expect(described_class.new).to be_retryable
+    end
+
+    it 'carries reasons through the kwarg' do
+      reasons = [{ provider: :vllm, reason: :discovery_unavailable }]
+      err = described_class.new(reasons: reasons)
+      expect(err.reasons).to eq(reasons)
+      expect(err.status_code).to eq(425)
+    end
+  end
+
+  describe Legion::LLM::RoutingFailedDependency do
+    it 'is not retryable' do
+      expect(described_class.new).not_to be_retryable
+    end
+
+    it 'carries reasons through the kwarg' do
+      reasons = [{ provider: :bedrock, reason: :model_denied }]
+      err = described_class.new(reasons: reasons)
+      expect(err.reasons).to eq(reasons)
+      expect(err.status_code).to eq(424)
+    end
+  end
+
   describe Legion::LLM::InferenceError do
     it 'wraps a step name' do
       err = described_class.new('boom', step: :routing)

--- a/spec/legion/llm/inference/executor_escalation_circuit_spec.rb
+++ b/spec/legion/llm/inference/executor_escalation_circuit_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe Legion::LLM::Inference::Executor, 'escalation circuit guard' do
   end
 
   describe 'skipping open circuits' do
+    after do
+      Legion::LLM::Call::Registry.deregister_provider(:bedrock)
+      Legion::LLM::Call::Registry.deregister_provider(:vllm)
+    end
+
     it 'skips a resolution whose circuit is open and uses the next one' do
       trip_circuit(provider: :vllm, instance: :h200)
 
@@ -85,7 +90,7 @@ RSpec.describe Legion::LLM::Inference::Executor, 'escalation circuit guard' do
       expect { executor.call }.to raise_error(Legion::LLM::EscalationExhausted)
     end
 
-    it 'raises a routing error with no_available_provider on empty chain' do
+    it 'raises EscalationExhausted on an empty chain with no rejection reasons' do
       empty_chain = build_chain
       allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
       allow(Legion::LLM::Router).to receive(:resolve_chain).and_return(empty_chain)
@@ -95,14 +100,29 @@ RSpec.describe Legion::LLM::Inference::Executor, 'escalation circuit guard' do
       executor = described_class.new(request)
       executor.instance_variable_set(:@escalation_chain, empty_chain)
 
-      expect { executor.call }.to raise_error do |error|
-        expect(error).to be_a(Legion::LLM::EscalationExhausted)
-                     .or be_a(Legion::LLM::RoutingFailedDependency)
-      end
+      expect { executor.call }.to raise_error(Legion::LLM::EscalationExhausted)
+    end
+
+    it 'raises RoutingFailedDependency on an empty chain whose rejection reasons indicate a hard prerequisite failure' do
+      empty_chain = build_chain
+      allow(empty_chain).to receive(:rejection_reasons).and_return(
+        [{ provider: :vllm, instance: :h200, model: 'qwen3:32b', reason: :circuit_open }]
+      )
+      allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+      allow(Legion::LLM::Router).to receive(:resolve_chain).and_return(empty_chain)
+      allow(Legion::LLM::Router).to receive(:resolve).and_return(nil)
+      allow(Legion::LLM::Call::Registry).to receive(:all_instances).and_return([])
+
+      executor = described_class.new(request)
+      executor.instance_variable_set(:@escalation_chain, empty_chain)
+
+      expect { executor.call }.to raise_error(Legion::LLM::RoutingFailedDependency)
     end
   end
 
   describe 'failing over across instances of the same provider' do
+    after { Legion::LLM::Call::Registry.deregister_provider(:anthropic) }
+
     let(:anthropic_primary) do
       Legion::LLM::Router::Resolution.new(tier: :frontier, provider: :anthropic, instance: :primary, model: 'claude-haiku-4-5')
     end

--- a/spec/legion/llm/inference/executor_escalation_circuit_spec.rb
+++ b/spec/legion/llm/inference/executor_escalation_circuit_spec.rb
@@ -118,6 +118,25 @@ RSpec.describe Legion::LLM::Inference::Executor, 'escalation circuit guard' do
 
       expect { executor.call }.to raise_error(Legion::LLM::RoutingFailedDependency)
     end
+
+    it 'raises RoutingTooEarly (retryable, 425) on an empty chain whose rejection reasons indicate cold-boot discovery' do
+      empty_chain = build_chain
+      allow(empty_chain).to receive(:rejection_reasons).and_return(
+        [{ provider: :vllm, instance: :default, model: 'x', reason: :discovery_unavailable }]
+      )
+      allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+      allow(Legion::LLM::Router).to receive(:resolve_chain).and_return(empty_chain)
+      allow(Legion::LLM::Router).to receive(:resolve).and_return(nil)
+      allow(Legion::LLM::Call::Registry).to receive(:all_instances).and_return([])
+
+      executor = described_class.new(request)
+      executor.instance_variable_set(:@escalation_chain, empty_chain)
+
+      expect { executor.call }.to raise_error(Legion::LLM::RoutingTooEarly) do |error|
+        expect(error.retryable?).to be(true)
+        expect(error.status_code).to eq(425)
+      end
+    end
   end
 
   describe 'failing over across instances of the same provider' do

--- a/spec/legion/llm/inference/executor_spec.rb
+++ b/spec/legion/llm/inference/executor_spec.rb
@@ -573,7 +573,6 @@ confidence: 0.9 }],
     end
 
     it 'keeps failed fleet attempt metadata when escalation succeeds on a direct provider' do
-      skip 'fleet dispatch mock interacts with availability filtering in full-suite context'
       fleet_resolution = Legion::LLM::Router::Resolution.new(tier: :fleet, provider: :vllm, model: 'qwen3.6-27b')
       direct_resolution = Legion::LLM::Router::Resolution.new(tier: :cloud, provider: :anthropic, model: 'claude-opus-4-6')
       chain = Legion::LLM::Router::EscalationChain.new(resolutions: [fleet_resolution, direct_resolution], max_attempts: 2)
@@ -610,6 +609,8 @@ confidence: 0.9 }],
       expect(attempts.first).to include(status: :failure, failure_reason: 'fleet_timeout')
       expect(attempts.last).to include(status: :success, escalation: hash_including(attempt: 2))
       expect(response.message[:content]).to include('direct escalation answer')
+    ensure
+      Legion::LLM::Call::Registry.deregister_provider(:anthropic)
     end
   end
 

--- a/spec/legion/llm/router/availability_spec.rb
+++ b/spec/legion/llm/router/availability_spec.rb
@@ -69,8 +69,9 @@ RSpec.describe Legion::LLM::Router::Availability do
         tracker.instance_variable_get(:@circuits)[key][:state] = :half_open
       end
 
-      filtered, _reasons = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
+      filtered, reasons = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
       expect(filtered.map(&:provider)).to include(:vllm)
+      expect(reasons).to be_empty
     end
 
     it 'drops resolutions with denied models' do

--- a/spec/legion/llm/router/availability_spec.rb
+++ b/spec/legion/llm/router/availability_spec.rb
@@ -56,8 +56,9 @@ RSpec.describe Legion::LLM::Router::Availability do
     it 'drops resolutions with open circuits' do
       4.times { Legion::LLM::Router.health_tracker.report(provider: :vllm, instance: :h200, signal: :error, value: 1) }
 
-      result = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
-      expect(result.map(&:provider)).to eq([:bedrock])
+      filtered, reasons = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
+      expect(filtered.map(&:provider)).to eq([:bedrock])
+      expect(reasons).to include(hash_including(provider: :vllm, instance: :h200, reason: :circuit_open))
     end
 
     it 'keeps half-open circuits as recovery probes' do
@@ -68,15 +69,16 @@ RSpec.describe Legion::LLM::Router::Availability do
         tracker.instance_variable_get(:@circuits)[key][:state] = :half_open
       end
 
-      result = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
-      expect(result.map(&:provider)).to include(:vllm)
+      filtered, _reasons = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
+      expect(filtered.map(&:provider)).to include(:vllm)
     end
 
     it 'drops resolutions with denied models' do
       Legion::LLM::Router.health_tracker.deny_model(provider: :vllm, instance: :h200, model: 'qwen3:32b', reason: 'test')
 
-      result = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
-      expect(result.map(&:provider)).to eq([:bedrock])
+      filtered, reasons = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
+      expect(filtered.map(&:provider)).to eq([:bedrock])
+      expect(reasons).to include(hash_including(provider: :vllm, model: 'qwen3:32b', reason: :model_denied))
     end
 
     it 'drops resolutions missing required capabilities' do
@@ -89,24 +91,27 @@ RSpec.describe Legion::LLM::Router::Availability do
         model: 'phi:3b', metadata: { capabilities: %i[completion] }
       )
 
-      result = described_class.filter_resolutions(
+      filtered, reasons = described_class.filter_resolutions(
         [no_tools, bedrock_resolution],
         required_capabilities: [:tools]
       )
-      expect(result.map(&:provider)).to eq([:bedrock])
+      expect(filtered.map(&:provider)).to eq([:bedrock])
+      expect(reasons).to include(hash_including(provider: :ollama, reason: :missing_capability))
     end
 
     it 'returns empty array when all filtered' do
       Legion::LLM::Router.health_tracker.trip_circuit(provider: :vllm, instance: :h200, reason: 'test')
       Legion::LLM::Router.health_tracker.trip_circuit(provider: :bedrock, instance: :primary, reason: 'test')
 
-      result = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
-      expect(result).to be_empty
+      filtered, reasons = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
+      expect(filtered).to be_empty
+      expect(reasons.map { |r| r[:reason] }).to all(eq(:circuit_open))
     end
 
     it 'passes through when Inventory confirms models exist' do
-      result = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
-      expect(result.size).to eq(2)
+      filtered, reasons = described_class.filter_resolutions([vllm_resolution, bedrock_resolution])
+      expect(filtered.size).to eq(2)
+      expect(reasons).to be_empty
     end
   end
 
@@ -305,7 +310,7 @@ RSpec.describe Legion::LLM::Router::Availability do
       end
     end
 
-    it 'is permissive when Inventory lookup fails' do
+    it 'is permissive when Inventory lookup fails (inner rescue swallows offerings errors)' do
       allow(Legion::LLM::Inventory).to receive(:offerings).and_raise(StandardError, 'boom')
 
       reason = described_class.rejection_reason(
@@ -314,6 +319,17 @@ RSpec.describe Legion::LLM::Router::Availability do
         required_capabilities: []
       )
       expect(reason).to be_nil
+    end
+
+    it 'returns :availability_check_error when an availability check raises unexpectedly' do
+      allow(described_class).to receive(:discovery_status_for).and_raise(StandardError, 'boom')
+
+      reason = described_class.rejection_reason(
+        bedrock_resolution,
+        estimated_tokens:      nil,
+        required_capabilities: []
+      )
+      expect(reason).to eq(:availability_check_error)
     end
   end
 end

--- a/spec/legion/llm/router/determinism_spec.rb
+++ b/spec/legion/llm/router/determinism_spec.rb
@@ -24,36 +24,43 @@ RSpec.describe 'Router determinism and regression coverage' do
     Legion::LLM::Router.populate_auto_rules({})
   end
 
-  # ─── Regression: stale default_intent[:capability] raises ────────────────────
+  # ─── Regression: stale default_intent[:capability] is warn-stripped ──────────
 
   describe 'stale settings with capability: key' do
-    it 'raises ArgumentError from Router.resolve when default_intent contains capability:' do
+    before do
       Legion::Settings.set_prop(:llm, Legion::Settings[:llm].merge(
-                                        routing: {
+                                        default_provider: :vllm,
+                                        default_model:    'qwen3.6-27b',
+                                        routing:          {
                                           enabled:        true,
                                           rules:          [],
                                           default_intent: { privacy: 'normal', capability: 'moderate' }
                                         }
                                       ))
       Legion::LLM::Router.populate_auto_rules({})
+      allow(Legion::LLM::Router::Availability).to receive(:filter_resolutions) { |resolutions, **| [resolutions, []] }
+    end
+
+    it 'warns and strips :capability from default_intent in Router.resolve without raising' do
+      expect(Legion::LLM::Router.log).to receive(:warn).with(/deprecated :capability key/).at_least(:once)
+      expect(Legion::LLM::Router.log).to receive(:warn).with(any_args).at_least(:once)
 
       expect do
         Legion::LLM::Router.resolve(intent: { effort: :moderate })
-      end.to raise_error(ArgumentError, /capability.*removed/i)
+      end.not_to raise_error
     end
 
-    it 'raises ArgumentError from Router.resolve_chain when default_intent contains capability:' do
-      Legion::Settings.set_prop(:llm, Legion::Settings[:llm].merge(
-                                        routing: {
-                                          enabled:        true,
-                                          rules:          [],
-                                          default_intent: { privacy: 'normal', capability: 'moderate' }
-                                        }
-                                      ))
-      Legion::LLM::Router.populate_auto_rules({})
+    it 'warns and strips :capability from default_intent in Router.resolve_chain without raising' do
+      expect(Legion::LLM::Router.log).to receive(:warn).with(/deprecated :capability key/).at_least(:once)
 
       expect do
         Legion::LLM::Router.resolve_chain(intent: { effort: :moderate })
+      end.not_to raise_error
+    end
+
+    it 'still raises ArgumentError when :capability is supplied in the explicit caller intent' do
+      expect do
+        Legion::LLM::Router.resolve(intent: { capability: :moderate })
       end.to raise_error(ArgumentError, /capability.*removed/i)
     end
   end
@@ -405,7 +412,7 @@ RSpec.describe 'Router determinism and regression coverage' do
       )
       # Isolate the bug from availability: keep every candidate so a vLLM primary
       # proves the hint was ignored, not that availability filtered vLLM out.
-      allow(Legion::LLM::Router::Availability).to receive(:filter_resolutions) { |resolutions, **| resolutions }
+      allow(Legion::LLM::Router::Availability).to receive(:filter_resolutions) { |resolutions, **| [resolutions, []] }
     end
 
     after { Legion::LLM::Call::Registry.deregister_provider(:bedrock) }
@@ -436,7 +443,7 @@ RSpec.describe 'Router determinism and regression coverage' do
         :anthropic, Module.new,
         metadata: { tier: :frontier, default_model: 'qwen3.6-27b' }
       )
-      allow(Legion::LLM::Router::Availability).to receive(:filter_resolutions) { |resolutions, **| resolutions }
+      allow(Legion::LLM::Router::Availability).to receive(:filter_resolutions) { |resolutions, **| [resolutions, []] }
       # Inventory (SSOT) knows anthropic offers only haiku.
       allow(Legion::LLM::Inventory).to receive(:routing_candidates).and_call_original
       allow(Legion::LLM::Inventory).to receive(:routing_candidates).with(provider: :anthropic).and_return(

--- a/spec/legion/llm/router/determinism_spec.rb
+++ b/spec/legion/llm/router/determinism_spec.rb
@@ -45,17 +45,21 @@ RSpec.describe 'Router determinism and regression coverage' do
       expect(Legion::LLM::Router.log).to receive(:warn).with(/deprecated :capability key/).at_least(:once)
       expect(Legion::LLM::Router.log).to receive(:warn).with(any_args).at_least(:once)
 
+      result = nil
       expect do
-        Legion::LLM::Router.resolve(intent: { effort: :moderate })
+        result = Legion::LLM::Router.resolve(intent: { effort: :moderate })
       end.not_to raise_error
+      expect(result).not_to be_nil
     end
 
     it 'warns and strips :capability from default_intent in Router.resolve_chain without raising' do
       expect(Legion::LLM::Router.log).to receive(:warn).with(/deprecated :capability key/).at_least(:once)
 
+      chain = nil
       expect do
-        Legion::LLM::Router.resolve_chain(intent: { effort: :moderate })
+        chain = Legion::LLM::Router.resolve_chain(intent: { effort: :moderate })
       end.not_to raise_error
+      expect(chain).not_to be_nil
     end
 
     it 'still raises ArgumentError when :capability is supplied in the explicit caller intent' do

--- a/spec/legion/llm/router/multi_instance_spec.rb
+++ b/spec/legion/llm/router/multi_instance_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe 'Router multi-instance provider routing' do
                                                                    metadata: { default_model: 'claude-haiku-4-5-20251001', tier: :frontier })
       Legion::LLM::Call::Registry.register(:vllm, Module.new, instance: :apollo,
                                                               metadata: { default_model: 'gemma-4-12b-it', tier: :direct })
-      allow(Legion::LLM::Router::Availability).to receive(:filter_resolutions) { |resolutions, **| resolutions }
+      allow(Legion::LLM::Router::Availability).to receive(:filter_resolutions) { |resolutions, **| [resolutions, []] }
     end
 
     it 'includes both anthropic instances ahead of any other provider' do

--- a/spec/support/fake_provider.rb
+++ b/spec/support/fake_provider.rb
@@ -96,6 +96,7 @@ module FakeProvider
     def reset!
       Thread.current[:fake_provider_scenario] = nil
       Thread.current[:fake_provider_calls] = nil
+      Thread.current[:fake_server_tool_round] = nil
     end
 
     # G24 step 5: record every chat/responses dispatch so specs can assert


### PR DESCRIPTION
Stacked on #151. Addresses the merge-blocking subset of review findings (15 critical + 9 important + test order-dependence + doc accuracy). 33 files, +397/−175.

## Verification
- `bundle exec rubocop`: **0 offenses** (490 files)
- `bundle exec rspec`: **3247 examples, 1 failure, 0 pending**
  - Net vs base: +10 examples, −1 pending (un-skipped `executor_spec.rb:576`), 0 regressions
  - The 1 failure (`ask_spec.rb:413` — `try_defer` not reached via `chat_direct_governed`) is **pre-existing on `large-yolo-refactor`** (verified via stash) and touches files outside this diff

## Critical (C1–C15)
| # | Fix | Files |
|---|---|---|
| C1 | `Availability.filter_resolutions` / `Candidates.select_candidates` return `[result, reasons/trace]` instead of unsynchronized module ivars; threaded via `chain.rejection_reasons` | router/{availability,candidates}.rb, router.rb, executor/escalation.rb |
| C2 | `HealthTracker.known_instances` wrapped in Monitor | router/health_tracker.rb |
| C3 | `rejection_reason` fail-closed → `:availability_check_error` on exception | router/availability.rb |
| C4 | `:success` health report ungated from `@resolved_offering_id` (half-open circuits can close) | executor/escalation.rb |
| C5 | `internal_error?` guard — daemon `NoMethodError`/`ArgumentError` no longer trips provider circuits | executor/escalation.rb |
| C6 | Remove bare `/ValidationException/` from payload patterns; `bedrock_availability_error?` → deny/trip | executor.rb, executor/escalation.rb |
| C7 | `routing[:model] \|\|= body[:model]` — SDK clients' model param honored | client_translators/{anthropic_messages,openai_chat,openai_responses}.rb |
| C8 | OpenAI Chat streaming `tool_calls[].index` = 0-based ordinal, not global block_index | client_translators/openai_chat.rb |
| C9 | OpenAI Responses streaming: track `server_tool`; only client tools → `requires_action` | client_translators/openai_responses.rb |
| C10 | Anthropic: preserve `thinking_blocks` on assistant parse for same-provider replay | client_translators/anthropic_messages.rb |
| C11 | Anthropic: preserve `image`/`document` as `content_blocks` instead of `Hash#to_s` | client_translators/anthropic_messages.rb |
| C12 | `parse_arguments`: log non-Hash JSON + truncated raw on parse failure | call/dispatch.rb |
| C13 | `safe_call`: narrow `rescue Exception` → `NoMethodError`/`StandardError` + RSpec guard | api/stream_assembler.rb |
| C14 | `step_tier_assignment`: re-raise (fail-closed for privacy/security tier constraints) | executor/routing.rb |
| C15 | `merge_defaults`: strip-and-warn deprecated `:capability` from settings `default_intent` (still raises on caller intent) | router.rb |

## Important (I1–I3, I6, I7, I12, I13, I16–I18)
- **I1** `Capabilities.normalize`: canonical-replace aliases (`[:tools]` now satisfies `required: [:function_calling]`)
- **I2** `RoutingUnavailable`/`TooEarly` `retryable? = true`; `FailedDependency` explicit `false`; all carry `reasons:`
- **I3** `routing_empty_chain_error(reasons)`: maps actual Availability symbols (`:discovery_unavailable` → 425, `:circuit_open`/etc → 424)
- **I6** `resolve_chain` forwards `estimated_tokens`/`required_capabilities` to `chain_from_defaults`
- **I7** `normalize_model_for_rules` copies `:loaded` so `loaded_model_bonus` actually fires
- **I12** `handle_text_delta` closes open thinking block before opening text
- **I13** `Puma::ConnectionError` added to client-disconnect rescues (assembler + 3 routes)
- **I16** `0.90` context headroom unified → `Availability.context_headroom` (3 sites)
- **I17** `handle_exception` on bare rescues (tools/dispatcher, tools/special, debug_formats)
- **I18** `Capabilities` gets `extend Legion::Logging::Helper`

## Tests
- Registry teardown in `executor_escalation_circuit_spec`; `FakeProvider.reset!` clears `:fake_server_tool_round`
- `execution_proxy_matrix_spec`: `singleton_class.prepend` → `wrap_original` (no permanent mutation)
- `executor_spec.rb:576` un-skipped (root cause was Registry leak, fixed above)
- Spec updates for return-tuple signatures, canonical capability aliases, retryable contracts, C7/C15 behavior

## Docs
- `candidates.rb`/`routing.rb`/`escalation.rb`: drop false 'verbatim/no behavior change' claims; note 0.12.20/0.12.30/0.12.35 extensions
- StreamAssembler + CLAUDE.md Invariant 5: keep-alive is single-fire on tool-open, not periodic
- Remove dangling refs (P4b/P5/G23/A7-fixture); `candidates.rb:235` orphan fragment; CLAUDE.md example-count/relative-date

## Deferred to follow-up (needs @Esity input)
| # | Item | Why deferred |
|---|---|---|
| I4/I5 | `skip_same_tier!` vs `max_attempts` cap; `chain.size` vs effective attempts | Changes escalation iteration semantics — author should decide |
| I8 | `Dispatch` instance-fallback attribution | Behavior decision: fail vs fallback-with-correct-attribution |
| I9/I10/I11 | Responses streaming reasoning shape; `instructions`→`system`; unresolved server-tool leak | G24 contract decisions |
| I14 | Restore `**_opts` on `Router.resolve` | Intentional API tightening? |
| I15 | Six `false→true` setting flips | Confirm intentional or split out |
| — | `StreamAssembler` (706L, 1 example) + `ContextWindow` unit suites | Test debt, separate PR |
| — | Fail-open → fail-closed sweep on remaining availability predicates | Policy decision |
| — | `ask_spec.rb:413` pre-existing failure | Outside this diff |

## Merge order
Either: (a) merge this into `large-yolo-refactor` then merge #151, or (b) merge #151 first then retarget this to `main` (same base commit `4aa4240`).

Note: #151 is currently CODEOWNERS-deadlocked — `* @Esity` is the effective last-match rule and Esity is the author. Needs admin merge or CODEOWNERS fix.