### PR TITLE
fix: route rewrite for Kai /api/llm/inference/v1/* paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion LLM Changelog
 
+## [0.14.4] - 2026-06-23
+
+### Fixed
+
+- Added route rewrite for `/api/llm/inference/v1/*` → `/v1/*` so Kai (and other clients using the prefixed path) can reach OpenAI-compat endpoints like `/v1/chat/completions`.
+
 ## [0.14.3] - 2026-06-22
 
 ### Fixed

--- a/lib/legion/llm/api/namespaces/registration.rb
+++ b/lib/legion/llm/api/namespaces/registration.rb
@@ -89,6 +89,12 @@ module Legion
               register Namespaces::Native::Inference
             end
 
+            # Kai sends requests to /api/llm/inference/v1/chat/completions —
+            # rewrite to the canonical /v1/chat/completions route.
+            app.before '/api/llm/inference/v1/*' do
+              env['PATH_INFO'] = "/v1/#{params['splat'].first}"
+            end
+
             log.debug('[llm][api][namespaces] native routes registered')
           end
 

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.14.3'
+    VERSION = '0.14.4'
   end
 end


### PR DESCRIPTION
## Summary

- Kai sends OpenAI-compat requests to `/api/llm/inference/v1/chat/completions` but the handler lives at `/v1/chat/completions`
- Added a `before` filter in registration that rewrites `/api/llm/inference/v1/*` → `/v1/*`
- Bumped to v0.14.4

## Test plan

- [x] All 588 API specs pass
- [ ] Kai can hit `/api/llm/inference/v1/chat/completions` and get a response