### PR TITLE
fix: ContentBlock inspect leak + context compaction loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Legion LLM Changelog
 
+## [0.14.6] - 2026-06-25
+
+### Fixed
+
+- `step_context_store` stores `typed_msg.text` (extracted string) instead of `typed_msg.content` (raw Array), preventing ContentBlock objects from being serialized as `#inspect` strings in conversation history.
+- `Types::Message#text_from_block` recognizes `output_text`/`input_text` content block types so token estimation and text extraction work for Responses API content.
+- `lex_llm_adapter.rb` `text_part_content` Data struct branch handles `output_text`/`input_text` types (previously only matched `type == 'text'`).
+- `context_window.rb` `compact_to_fit` loops halving until messages fit the target token budget instead of a single halve that leaves payloads 2x over threshold for very large conversations.
+
+## [0.14.5] - 2026-06-24
+
+### Fixed
+
+- Non-pipeline metering (`emit_non_pipeline_metering`) now correctly reads token counts from `response.usage` instead of the non-existent top-level `input_tokens`/`output_tokens` on `Canonical::Response`. Previously all internal LLM calls (via `Legion::LLM.structured`, `chat_single_native`) emitted zero-token metering events.
+- Non-pipeline metering now includes `messages` and `response_content` fields, fixing null request/response JSON columns in the ledger for internal extension calls (lex-apollo, lex-agentic-self, legion-gaia, etc.).
+- Non-pipeline metering reads `response.metadata` (correct field) instead of `response.meta` (does not exist on `Canonical::Response`) for latency/timing extraction.
+
 ## [0.14.4] - 2026-06-23
 
 ### Fixed

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -753,7 +753,7 @@ module Legion
           if part.respond_to?(:type) || part.respond_to?(:text)
             type = (part.respond_to?(:type) ? part.type.to_s : '')
             text = part.respond_to?(:text) ? part.text : nil
-            return text.to_s if type == 'text' || (type.empty? && !text.nil?)
+            return text.to_s if %w[text output_text input_text].include?(type) || (type.empty? && !text.nil?)
 
             return nil
           end

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -947,7 +947,7 @@ module Legion
 
             attrs = {
               role:            typed_msg.role,
-              content:         typed_msg.content,
+              content:         typed_msg.text,
               conversation_id: conv_id,
               task_id:         typed_msg.task_id
             }

--- a/lib/legion/llm/inference/executor/context_window.rb
+++ b/lib/legion/llm/inference/executor/context_window.rb
@@ -83,8 +83,8 @@ module Legion
 
             return messages if estimate_message_tokens(messages) <= target_tokens
 
-            half = messages.size / 2
-            messages.last(half)
+            messages = messages.last(messages.size / 2) while messages.size > 2 && estimate_message_tokens(messages) > target_tokens
+            messages
           end
 
           def resolved_context_window

--- a/lib/legion/llm/types/message.rb
+++ b/lib/legion/llm/types/message.rb
@@ -93,7 +93,7 @@ module Legion
           return nil unless block.is_a?(Hash)
 
           type = block[:type] || block['type']
-          return nil unless type.nil? || type.to_s == 'text'
+          return nil unless type.nil? || %w[text output_text input_text].include?(type.to_s)
 
           block[:text] || block['text'] || block[:content] || block['content']
         end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.14.4'
+    VERSION = '0.14.6'
   end
 end

--- a/spec/legion/llm/api/matrix/openai_responses_matrix_spec.rb
+++ b/spec/legion/llm/api/matrix/openai_responses_matrix_spec.rb
@@ -154,6 +154,57 @@ RSpec.describe '[matrix] /v1/responses (OpenAI Responses) × FakeProvider', type
     end
   end
 
+  describe 'scenario: output_text in history (Codex multi-turn with content blocks)' do
+    # Reproduction for ContentBlock#inspect leak: when Codex sends previous
+    # assistant output_text blocks in the conversation history, the daemon must
+    # normalize them to :text so Message#text extracts correctly. Without the
+    # fix, ContentBlock(type: :output_text) leaks #inspect into the response.
+    it 'handles output_text content blocks in assistant history without leaking #inspect' do
+      FakeProvider.with_scenario(:text) do
+        resp = post_responses(
+          model: 'fake-default',
+          input: [
+            { role: 'user', content: 'What templates exist?' },
+            { role: 'assistant', content: [{ type: 'output_text', text: "The seat templates don't apply here." }] },
+            { role: 'user', content: 'OK thanks' }
+          ]
+        )
+        expect(resp.status).to eq(200)
+        body = Legion::JSON.load(resp.body)
+        message_items = body[:output].select { |i| i[:type] == 'message' }
+        text_blocks = message_items.first[:content].select { |c| c[:type] == 'output_text' }
+        expect(text_blocks.first[:text]).to eq('Hello there.')
+        expect(text_blocks.first[:text]).not_to include('#<data')
+      end
+    end
+  end
+
+  describe 'scenario: corrupted ContentBlock#inspect strings in content history' do
+    # Reproduction for conv_id 147191: content arrays contain stringified
+    # ContentBlock inspect output from a prior serialization bug. The daemon
+    # must handle these gracefully — not crash with transform_keys NoMethodError.
+    it 'handles String elements in content arrays without crashing' do
+      FakeProvider.with_scenario(:text) do
+        corrupted_user = '#<data Legion::Extensions::Llm::Canonical::ContentBlock type=:input_text, ' \
+                         'text="What is 2+2?", data=nil, source_type=nil, media_type=nil, ' \
+                         'detail=nil, name=nil, file_id=nil, id=nil, input=nil, tool_use_id=nil, ' \
+                         'is_error=nil, source=nil, start_index=nil, end_index=nil, code=nil, message=nil, cache_control=nil>'
+
+        resp = post_responses(
+          model: 'fake-default',
+          input: [
+            { role: 'user', content: [corrupted_user] },
+            { role: 'user', content: [{ type: 'input_text', text: 'Say hello.' }] }
+          ]
+        )
+        expect(resp.status).to eq(200)
+        body = Legion::JSON.load(resp.body)
+        expect(body[:object]).to eq('response')
+        expect(body[:status]).to eq('completed')
+      end
+    end
+  end
+
   describe 'scenario: streaming text' do
     it 'emits response.created → in_progress → output_text.delta → response.completed' do
       FakeProvider.with_scenario(:stream_text) do

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -685,4 +685,37 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
     expect(result.last.name).to eq('ruby')
     expect(result.last.arguments).to eq(code: 'puts 1')
   end
+
+  # Reproduction for ContentBlock#inspect leak (2026-06-25):
+  # When ContentBlock objects with type :output_text flow through
+  # normalize_message_content (e.g. replayed history from canonical messages),
+  # the Data struct branch must extract .text, not return nil and fall through
+  # to Array#to_s which dumps the raw #inspect.
+  it 'extracts text from ContentBlock objects with output_text type in message content' do
+    canonical_ns = ::Legion::Extensions::Llm::Canonical
+    content_blocks = [
+      canonical_ns::ContentBlock.from_hash(type: 'output_text', text: "The seat templates don't apply here.")
+    ]
+
+    provider_class.define_method(:complete) do |messages, model:, **|
+      # Verify the content passed to the provider is a clean string, not inspect output
+      assistant_msg = messages.find { |m| m.role == :assistant }
+      content_text = assistant_msg&.content
+      llm_namespace::Message.new(role: :assistant, content: "got: #{content_text}", model_id: model.id,
+                                 input_tokens: 10, output_tokens: 5)
+    end
+
+    messages = [
+      { role: 'user', content: 'What templates exist?' },
+      { role: 'assistant', content: content_blocks },
+      { role: 'user', content: 'OK thanks' }
+    ]
+
+    result = adapter.chat(model: 'model-a', messages: messages)
+
+    expect(result[:result]).not_to include('#<data')
+    expect(result[:result]).not_to include('ContentBlock')
+    expect(result[:result]).not_to include('source_type=nil')
+    expect(result[:result]).to include("The seat templates don't apply here.")
+  end
 end


### PR DESCRIPTION
## Summary
- `step_context_store` stores `typed_msg.text` instead of `.content` — prevents ContentBlock arrays from serializing as `#inspect` strings
- `Types::Message#text_from_block` handles `output_text`/`input_text` content block types
- `lex_llm_adapter.rb` Data struct branch handles `output_text`/`input_text`
- `compact_to_fit` loops halving until under target token budget (was single-pass)

## Root Causes
1. **ContentBlock leak**: `step_context_store` stored raw arrays → `Array#inspect` → corrupted strings in history → `NoMethodError` on replay
2. **Context overflow**: Single halve of 30k messages (854k tokens) → 15k (427k) still exceeds 235k threshold → `ContextOverflow` → 503

## Test plan
- [x] 3097 legion-llm specs pass
- [x] 0 rubocop offenses on changed files
- [x] Matrix harness: corrupted content spec passes (was 500)
- [x] Adapter spec: ContentBlock leak reproduction passes
- [x] e2e `content_block_leak_spec` passes (was 500 transform_keys crash)
- [x] e2e `context_overflow_spec` passes (was 503 escalation_exhausted)
- [x] Full e2e suite 34/34 green