### PR TITLE
fix: ContentBlock inspect leak, context compaction, non-pipeline metering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Legion LLM Changelog
 
+## [0.14.6] - 2026-06-25
+
+### Fixed
+
+- `step_context_store` stores `typed_msg.text` (extracted string) instead of `typed_msg.content` (raw Array), preventing ContentBlock objects from being serialized as `#inspect` strings in conversation history.
+- `Types::Message#text_from_block` recognizes `output_text`/`input_text` content block types so token estimation and text extraction work for Responses API content.
+- `lex_llm_adapter.rb` `text_part_content` Data struct branch handles `output_text`/`input_text` types (previously only matched `type == 'text'`).
+- `context_window.rb` `compact_to_fit` loops halving until messages fit the target token budget instead of a single halve that leaves payloads 2x over threshold for very large conversations.
+
+## [0.14.5] - 2026-06-24
+
+### Fixed
+
+- Non-pipeline metering (`emit_non_pipeline_metering`) now correctly reads token counts from `response.usage` instead of the non-existent top-level `input_tokens`/`output_tokens` on `Canonical::Response`. Previously all internal LLM calls (via `Legion::LLM.structured`, `chat_single_native`) emitted zero-token metering events.
+- Non-pipeline metering now includes `messages` and `response_content` fields, fixing null request/response JSON columns in the ledger for internal extension calls (lex-apollo, lex-agentic-self, legion-gaia, etc.).
+- Non-pipeline metering reads `response.metadata` (correct field) instead of `response.meta` (does not exist on `Canonical::Response`) for latency/timing extraction.
+
 ## [0.14.4] - 2026-06-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion LLM Changelog
 
+## [0.14.8] - 2026-06-25
+
+### Fixed
+
+- Responses translator (`format_response`) no longer emits a message item with empty `output_text` when the response is pure tool_use (function_call items present). The empty text triggered Codex's `[Your previous response had no visible output]` injection on every tool turn.
+
 ## [0.14.7] - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Legion LLM Changelog
 
-## [0.14.6] - 2026-06-25
+## [0.14.7] - 2026-06-25
 
 ### Fixed
 
@@ -8,6 +8,8 @@
 - `Types::Message#text_from_block` recognizes `output_text`/`input_text` content block types so token estimation and text extraction work for Responses API content.
 - `lex_llm_adapter.rb` `text_part_content` Data struct branch handles `output_text`/`input_text` types (previously only matched `type == 'text'`).
 - `context_window.rb` `compact_to_fit` loops halving until messages fit the target token budget instead of a single halve that leaves payloads 2x over threshold for very large conversations.
+- `emit_non_pipeline_metering` reads tokens from `response.usage.input_tokens` (correct) instead of `response.input_tokens` (non-existent on Canonical::Response), fixing zero-token metering for internal extension LLM calls (lex-apollo, legion-gaia, lex-knowledge, etc.).
+- `emit_non_pipeline_metering` reads `response.metadata` instead of `response.meta`, passes `messages` and `response_content` to metering events.
 
 ## [0.14.5] - 2026-06-24
 

--- a/legion-llm.gemspec
+++ b/legion-llm.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'legion-settings', '>= 1.4.0'
   spec.add_dependency 'legion-transport', '>= 1.4.14'
   spec.add_dependency 'lex-knowledge'
-  spec.add_dependency 'lex-llm', '>= 0.6.0'
+  spec.add_dependency 'lex-llm', '>= 0.6.3'
   spec.add_dependency 'pdf-reader'
   spec.add_dependency 'sinatra-contrib', '>= 2.0'
   spec.add_dependency 'tzinfo', '>= 2.0'

--- a/lib/legion/llm/api/client_translators/openai_responses.rb
+++ b/lib/legion/llm/api/client_translators/openai_responses.rb
@@ -151,18 +151,16 @@ module Legion
             server_tool_items = build_output_server_tool_items(pipeline_response)
             reasoning = build_output_reasoning(pipeline_response)
 
-            output = [
-              *reasoning,
-              *server_tool_items,
-              *actionable_tool_calls,
-              {
+            output = [*reasoning, *server_tool_items, *actionable_tool_calls]
+            unless content.to_s.strip.empty? && (actionable_tool_calls.any? || server_tool_items.any?)
+              output << {
                 type:    'message',
                 id:      "msg_#{SecureRandom.hex(12)}",
                 role:    'assistant',
                 content: [{ type: 'output_text', text: content }],
                 status:  'completed'
               }
-            ]
+            end
 
             # Responses protocol: a turn is always status `completed`. Both
             # client-callable calls (actionable_tool_calls) and LegionIO-run

--- a/lib/legion/llm/call/lex_llm_adapter.rb
+++ b/lib/legion/llm/call/lex_llm_adapter.rb
@@ -753,7 +753,7 @@ module Legion
           if part.respond_to?(:type) || part.respond_to?(:text)
             type = (part.respond_to?(:type) ? part.type.to_s : '')
             text = part.respond_to?(:text) ? part.text : nil
-            return text.to_s if type == 'text' || (type.empty? && !text.nil?)
+            return text.to_s if %w[text output_text input_text].include?(type) || (type.empty? && !text.nil?)
 
             return nil
           end

--- a/lib/legion/llm/inference.rb
+++ b/lib/legion/llm/inference.rb
@@ -896,7 +896,7 @@ module Legion
         usage = response.respond_to?(:usage) ? response.usage : nil
         input    = usage.respond_to?(:input_tokens)    ? usage.input_tokens.to_i    : 0
         output   = usage.respond_to?(:output_tokens)   ? usage.output_tokens.to_i   : 0
-        thinking = usage.respond_to?(:thinking_tokens)  ? usage.thinking_tokens.to_i  : 0
+        thinking = usage.respond_to?(:thinking_tokens) ? usage.thinking_tokens.to_i : 0
 
         finish = nil
         if response.respond_to?(:stop_reason)

--- a/lib/legion/llm/inference.rb
+++ b/lib/legion/llm/inference.rb
@@ -605,7 +605,7 @@ module Legion
                    Call::Dispatch.call(provider: provider, instance: instance, capability: :chat, model: model,
                                        messages: messages, **)
                  end
-        emit_non_pipeline_metering(result, model: model, provider: provider, caller: caller)
+        emit_non_pipeline_metering(result, model: model, provider: provider, caller: caller, messages: messages)
         result
       end
 
@@ -890,14 +890,13 @@ module Legion
         esc[:quality_threshold] || 50
       end
 
-      def emit_non_pipeline_metering(response, model:, provider:, caller: nil)
+      def emit_non_pipeline_metering(response, model:, provider:, caller: nil, messages: nil)
         return unless response
 
-        input  = response.respond_to?(:input_tokens)  ? response.input_tokens.to_i  : 0
-        output = response.respond_to?(:output_tokens) ? response.output_tokens.to_i : 0
-        usage = response.respond_to?(:usage) ? response.usage : {}
-        usage_hash = usage.is_a?(Hash) ? usage : {}
-        thinking = (usage_hash[:thinking_tokens] || usage_hash[:thinking] || 0).to_i
+        usage = response.respond_to?(:usage) ? response.usage : nil
+        input    = usage.respond_to?(:input_tokens)    ? usage.input_tokens.to_i    : 0
+        output   = usage.respond_to?(:output_tokens)   ? usage.output_tokens.to_i   : 0
+        thinking = usage.respond_to?(:thinking_tokens)  ? usage.thinking_tokens.to_i  : 0
 
         finish = nil
         if response.respond_to?(:stop_reason)
@@ -906,10 +905,16 @@ module Legion
           finish = response.stop[:reason]&.to_s
         end
 
-        meta = response.respond_to?(:meta) ? response.meta : {}
+        meta = response.respond_to?(:metadata) ? response.metadata : {}
         meta_hash = meta.is_a?(Hash) ? meta : {}
         latency = (meta_hash[:latency_ms] || meta_hash.dig(:timing, :latency_ms) || 0).to_i
         wall_clock = (meta_hash[:wall_clock_ms] || meta_hash.dig(:timing, :wall_clock_ms) || 0).to_i
+
+        response_content = if response.respond_to?(:text)
+                             response.text
+                           elsif response.respond_to?(:content)
+                             response.content
+                           end
 
         Legion::LLM::Metering.emit(
           provider:          provider,
@@ -926,7 +931,9 @@ module Legion
           wall_clock_ms:     wall_clock,
           caller:            caller,
           event_type:        'llm_completion',
-          status:            'success'
+          status:            'success',
+          messages:          messages,
+          response_content:  response_content
         )
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'llm.inference.non_pipeline_metering')

--- a/lib/legion/llm/inference/executor.rb
+++ b/lib/legion/llm/inference/executor.rb
@@ -947,7 +947,7 @@ module Legion
 
             attrs = {
               role:            typed_msg.role,
-              content:         typed_msg.content,
+              content:         typed_msg.text,
               conversation_id: conv_id,
               task_id:         typed_msg.task_id
             }

--- a/lib/legion/llm/inference/executor/context_window.rb
+++ b/lib/legion/llm/inference/executor/context_window.rb
@@ -83,8 +83,8 @@ module Legion
 
             return messages if estimate_message_tokens(messages) <= target_tokens
 
-            half = messages.size / 2
-            messages.last(half)
+            messages = messages.last(messages.size / 2) while messages.size > 2 && estimate_message_tokens(messages) > target_tokens
+            messages
           end
 
           def resolved_context_window

--- a/lib/legion/llm/types/message.rb
+++ b/lib/legion/llm/types/message.rb
@@ -93,7 +93,7 @@ module Legion
           return nil unless block.is_a?(Hash)
 
           type = block[:type] || block['type']
-          return nil unless type.nil? || type.to_s == 'text'
+          return nil unless type.nil? || %w[text output_text input_text].include?(type.to_s)
 
           block[:text] || block['text'] || block[:content] || block['content']
         end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.14.4'
+    VERSION = '0.14.6'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.14.7'
+    VERSION = '0.14.8'
   end
 end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.14.6'
+    VERSION = '0.14.7'
   end
 end

--- a/spec/legion/llm/api/matrix/openai_responses_matrix_spec.rb
+++ b/spec/legion/llm/api/matrix/openai_responses_matrix_spec.rb
@@ -154,6 +154,57 @@ RSpec.describe '[matrix] /v1/responses (OpenAI Responses) × FakeProvider', type
     end
   end
 
+  describe 'scenario: output_text in history (Codex multi-turn with content blocks)' do
+    # Reproduction for ContentBlock#inspect leak: when Codex sends previous
+    # assistant output_text blocks in the conversation history, the daemon must
+    # normalize them to :text so Message#text extracts correctly. Without the
+    # fix, ContentBlock(type: :output_text) leaks #inspect into the response.
+    it 'handles output_text content blocks in assistant history without leaking #inspect' do
+      FakeProvider.with_scenario(:text) do
+        resp = post_responses(
+          model: 'fake-default',
+          input: [
+            { role: 'user', content: 'What templates exist?' },
+            { role: 'assistant', content: [{ type: 'output_text', text: "The seat templates don't apply here." }] },
+            { role: 'user', content: 'OK thanks' }
+          ]
+        )
+        expect(resp.status).to eq(200)
+        body = Legion::JSON.load(resp.body)
+        message_items = body[:output].select { |i| i[:type] == 'message' }
+        text_blocks = message_items.first[:content].select { |c| c[:type] == 'output_text' }
+        expect(text_blocks.first[:text]).to eq('Hello there.')
+        expect(text_blocks.first[:text]).not_to include('#<data')
+      end
+    end
+  end
+
+  describe 'scenario: corrupted ContentBlock#inspect strings in content history' do
+    # Reproduction for conv_id 147191: content arrays contain stringified
+    # ContentBlock inspect output from a prior serialization bug. The daemon
+    # must handle these gracefully — not crash with transform_keys NoMethodError.
+    it 'handles String elements in content arrays without crashing' do
+      FakeProvider.with_scenario(:text) do
+        corrupted_user = '#<data Legion::Extensions::Llm::Canonical::ContentBlock type=:input_text, ' \
+                         'text="What is 2+2?", data=nil, source_type=nil, media_type=nil, ' \
+                         'detail=nil, name=nil, file_id=nil, id=nil, input=nil, tool_use_id=nil, ' \
+                         'is_error=nil, source=nil, start_index=nil, end_index=nil, code=nil, message=nil, cache_control=nil>'
+
+        resp = post_responses(
+          model: 'fake-default',
+          input: [
+            { role: 'user', content: [corrupted_user] },
+            { role: 'user', content: [{ type: 'input_text', text: 'Say hello.' }] }
+          ]
+        )
+        expect(resp.status).to eq(200)
+        body = Legion::JSON.load(resp.body)
+        expect(body[:object]).to eq('response')
+        expect(body[:status]).to eq('completed')
+      end
+    end
+  end
+
   describe 'scenario: streaming text' do
     it 'emits response.created → in_progress → output_text.delta → response.completed' do
       FakeProvider.with_scenario(:stream_text) do

--- a/spec/legion/llm/call/lex_llm_adapter_spec.rb
+++ b/spec/legion/llm/call/lex_llm_adapter_spec.rb
@@ -685,4 +685,37 @@ RSpec.describe Legion::LLM::Call::LexLLMAdapter do
     expect(result.last.name).to eq('ruby')
     expect(result.last.arguments).to eq(code: 'puts 1')
   end
+
+  # Reproduction for ContentBlock#inspect leak (2026-06-25):
+  # When ContentBlock objects with type :output_text flow through
+  # normalize_message_content (e.g. replayed history from canonical messages),
+  # the Data struct branch must extract .text, not return nil and fall through
+  # to Array#to_s which dumps the raw #inspect.
+  it 'extracts text from ContentBlock objects with output_text type in message content' do
+    canonical_ns = ::Legion::Extensions::Llm::Canonical
+    content_blocks = [
+      canonical_ns::ContentBlock.from_hash(type: 'output_text', text: "The seat templates don't apply here.")
+    ]
+
+    provider_class.define_method(:complete) do |messages, model:, **|
+      # Verify the content passed to the provider is a clean string, not inspect output
+      assistant_msg = messages.find { |m| m.role == :assistant }
+      content_text = assistant_msg&.content
+      llm_namespace::Message.new(role: :assistant, content: "got: #{content_text}", model_id: model.id,
+                                 input_tokens: 10, output_tokens: 5)
+    end
+
+    messages = [
+      { role: 'user', content: 'What templates exist?' },
+      { role: 'assistant', content: content_blocks },
+      { role: 'user', content: 'OK thanks' }
+    ]
+
+    result = adapter.chat(model: 'model-a', messages: messages)
+
+    expect(result[:result]).not_to include('#<data')
+    expect(result[:result]).not_to include('ContentBlock')
+    expect(result[:result]).not_to include('source_type=nil')
+    expect(result[:result]).to include("The seat templates don't apply here.")
+  end
 end


### PR DESCRIPTION
## Summary
- `ContentBlock.from_hash` rescue for corrupted String inputs (NoMethodError crash)
- `step_context_store` stores extracted text, not raw ContentBlock arrays
- `compact_to_fit` loops halving until under budget (was single-pass, 30k msgs overflowed)
- `emit_non_pipeline_metering` reads `response.usage` correctly for extension LLM calls
- `Types::Message#text_from_block` and `lex_llm_adapter` handle `output_text`/`input_text`

## Root Causes
1. **ContentBlock leak** (conv_id 147191): context_store serialized Arrays via #inspect → corrupted Strings replayed → crash
2. **Context overflow** (30k messages): single halve insufficient for 2x+ oversize payloads
3. **Zero-token metering**: non-pipeline path read non-existent fields on Canonical::Response

## Test plan
- [x] 3097 legion-llm specs pass, 0 rubocop offenses on changed files
- [x] Matrix: corrupted content spec passes (was 500)
- [x] e2e: content_block_leak_spec passes (was 500 transform_keys crash)
- [x] e2e: context_overflow_spec passes (was 503 escalation_exhausted)
- [x] Full e2e 34/34 green