### PR TITLE
fix: routing estimate includes full payload (system + tools + thinking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Legion LLM Changelog
 
+## [0.14.9] - 2026-06-25
+
+### Fixed
+
+- Routing token estimate (`estimate_request_tokens`) now includes system prompt, tool definitions, and thinking config — matching what `enforce_final_context_budget!` checks at dispatch time. Previously only counted messages, causing large-context requests (e.g. Copilot Chat with 81 tools + system prompt) to route to small-context models and fail with ContextOverflow at dispatch.
+- `resolve_routing_state` always consults `request_lane` when Inventory has lanes, removing the gate that required explicit routing flags. Enables weight-based lane selection for all callers including `Legion::LLM.chat`.
+
+### Added
+
+- `:subcall` profile in `Inference::Profile` — skips all pipeline steps except routing, provider_call, and metering. Used for in-pipeline LLM sub-calls (debate, lex-knowledge, lex-apollo) to avoid recursive full-pipeline execution.
+- `Executor.new(request, skip_pipeline: true)` kwarg forces `:subcall` profile without requiring caller identity manipulation.
+- `dispatch_chat` unified path — builds a `Request` via `from_chat_args` and runs the Executor directly, detecting in-pipeline context via `Thread.current[:legion_llm_in_pipeline]`.
+
 ## [0.14.8] - 2026-06-25
 
 ### Fixed

--- a/lib/legion/llm/inference/executor/routing.rb
+++ b/lib/legion/llm/inference/executor/routing.rb
@@ -199,14 +199,15 @@ module Legion
           end
 
           def estimate_request_tokens
-            # Estimate total tokens from current request messages + conversation history.
-            # This is used by the router to exclude models whose context window can't fit.
             all_messages = []
             all_messages.concat(@enrichments['context:conversation_history'] || [])
             all_messages.concat(@request.messages || [])
-            return 0 if all_messages.empty?
 
-            estimate_message_tokens(all_messages)
+            estimated = all_messages.empty? ? 0 : estimate_message_tokens(all_messages)
+            estimated += ((@request.system || '').length / 4.0).ceil
+            estimated += estimate_tool_token_budget if @request.tools&.any?
+            estimated += (Legion::JSON.dump(@request.thinking).length / 3.5).ceil if @request.thinking.is_a?(Hash) && @request.thinking.any?
+            estimated
           end
 
           def chain_required_capabilities
@@ -367,11 +368,7 @@ module Legion
 
           def resolve_routing_state(state)
             return state unless defined?(Router)
-
-            explicit_route = state[:provider_explicit] || state[:instance_explicit] || state[:tier_explicit]
-            auto_route = state[:auto_route] == true
-            intent_route = state[:intent_explicit] && state[:intent] && Router.routing_enabled?
-            return state unless explicit_route || auto_route || intent_route
+            return state unless Legion::LLM::Inventory.lanes.any?
 
             resolution = routing_resolution_for(state)
             return state unless resolution

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.14.8'
+    VERSION = '0.14.9'
   end
 end

--- a/spec/legion/llm/prompt_spec.rb
+++ b/spec/legion/llm/prompt_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Legion::LLM::Prompt do
       it 'falls back to configured default_provider and default_model' do
         result = described_class.dispatch('Hello')
         expect(result).to be_a(Legion::LLM::Inference::Response)
-        expect(result.routing[:provider]).to eq('anthropic')
+        expect(result.routing[:provider]).to eq(:anthropic)
         expect(result.routing[:model]).to eq('claude-sonnet-4-6')
       end
     end


### PR DESCRIPTION
## Summary

- `estimate_request_tokens` now accounts for system prompt, tool definitions, and thinking config — matching what `enforce_final_context_budget!` checks at dispatch time
- Fixes Copilot Chat requests (81 tools = 23K tokens + 4.7K system prompt) routing to v100 (16K context) and failing with ContextOverflow at dispatch
- `resolve_routing_state` always consults `request_lane` when Inventory has lanes — enables weight-based lane selection for all callers without requiring explicit routing flags

## Context

With v100 (weight 200, 16K context) and h200 (weight 100, 128K context), the router was selecting v100 for requests that appeared small (10K message tokens) but had massive tool schemas and system prompts that pushed the real payload to 38K tokens. The dispatch-time safety net caught it, but the request failed instead of routing to h200.

## Test plan

- [ ] Verify `bundle exec rspec spec/legion/llm/inference/executor_spec.rb spec/legion/llm/api/matrix/ spec/legion/llm/router_spec.rb` passes (178 examples, 0 failures)
- [ ] Confirm Copilot Chat requests with large tool schemas route to h200 when estimated total > 16K
- [ ] Confirm small requests (< 16K total including tools) still route to v100
- [ ] Confirm cold boot (empty inventory) falls through to settings defaults