### PR TITLE
fix: Prompt.dispatch stops pre-baking settings defaults when Inventor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion LLM Changelog
 
+## [0.14.10] - 2026-06-26
+
+### Fixed
+
+- `routing_resolution_for` now passes `chain_required_capabilities` to `request_lane` — requests with tools filter out lanes without `:tools` capability. Prevents tool-bearing requests from routing to models that can't handle function calling (e.g. v100 with `enable_tools: false`).
+- `Prompt.dispatch` no longer pre-bakes `default_provider`/`default_model` from settings when Inventory has lanes. Passes nil so the Executor's `step_routing` routes via `request_lane` using weight, context_window, and capabilities. Fixes GAIA/lex-agentic requests >16K getting locked to v100 by model filter instead of routing to h200.
+
 ## [0.14.9] - 2026-06-25
 
 ### Fixed

--- a/lib/legion/llm/inference/executor/routing.rb
+++ b/lib/legion/llm/inference/executor/routing.rb
@@ -388,6 +388,7 @@ module Legion
               providers:         providers,
               instances:         instances,
               models:            models,
+              capabilities:      chain_required_capabilities,
               estimated_context: state[:estimated_tokens],
               tried_lanes:       Array(state[:tried_lanes])
             )

--- a/lib/legion/llm/inference/prompt.rb
+++ b/lib/legion/llm/inference/prompt.rb
@@ -49,11 +49,9 @@ module Legion
             resolved_model    = lane&.dig(:model)
           end
 
-          unless auto_route
-            if resolved_provider.nil? && resolved_model.nil? && !Legion::LLM::Inventory.lanes.any?
-              resolved_provider = Legion::Settings[:llm][:default_provider]
-              resolved_model = Legion::Settings[:llm][:default_model]
-            end
+          if !auto_route && resolved_provider.nil? && resolved_model.nil? && Legion::LLM::Inventory.lanes.none?
+            resolved_provider = Legion::Settings[:llm][:default_provider]
+            resolved_model = Legion::Settings[:llm][:default_model]
           end
 
           request(message,
@@ -97,7 +95,7 @@ module Legion
                     quality_check: nil,
                     **)
           auto_route = Inference::Request.auto_routing_model?(model)
-          if !auto_route && (provider.nil? || model.nil?) && !Legion::LLM::Inventory.lanes.any?
+          if !auto_route && (provider.nil? || model.nil?) && Legion::LLM::Inventory.lanes.none?
             raise LLMError, "Prompt.request: provider and model must be set (got provider=#{provider.inspect}, model=#{model.inspect}). " \
                             'Configure Legion::Settings[:llm][:default_provider] and [:default_model], or pass them explicitly.'
           end

--- a/lib/legion/llm/inference/prompt.rb
+++ b/lib/legion/llm/inference/prompt.rb
@@ -49,8 +49,12 @@ module Legion
             resolved_model    = lane&.dig(:model)
           end
 
-          resolved_provider ||= Legion::Settings[:llm][:default_provider] unless auto_route
-          resolved_model ||= Legion::Settings[:llm][:default_model] unless auto_route
+          unless auto_route
+            if resolved_provider.nil? && resolved_model.nil? && !Legion::LLM::Inventory.lanes.any?
+              resolved_provider = Legion::Settings[:llm][:default_provider]
+              resolved_model = Legion::Settings[:llm][:default_model]
+            end
+          end
 
           request(message,
                   provider:         resolved_provider,
@@ -93,7 +97,7 @@ module Legion
                     quality_check: nil,
                     **)
           auto_route = Inference::Request.auto_routing_model?(model)
-          if !auto_route && (provider.nil? || model.nil?)
+          if !auto_route && (provider.nil? || model.nil?) && !Legion::LLM::Inventory.lanes.any?
             raise LLMError, "Prompt.request: provider and model must be set (got provider=#{provider.inspect}, model=#{model.inspect}). " \
                             'Configure Legion::Settings[:llm][:default_provider] and [:default_model], or pass them explicitly.'
           end

--- a/lib/legion/llm/version.rb
+++ b/lib/legion/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module LLM
-    VERSION = '0.14.9'
+    VERSION = '0.14.10'
   end
 end

--- a/spec/legion/llm/inference/pre_rollout_integration_spec.rb
+++ b/spec/legion/llm/inference/pre_rollout_integration_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe 'Pipeline pre-rollout integration' do
     Legion::Settings[:llm][:default_provider] = :test
     allow(Legion::LLM).to receive(:started?).and_return(true)
     stub_native_provider(content: 'pipeline response')
+    Legion::LLM::Inventory.reset_live_store!
+    Legion::LLM::Inventory.write_lane(lane: {
+      id: 'direct:test:default:inference:test-model',
+      tier: :direct, provider_family: :test, instance_id: :default,
+      model: 'test-model', type: :inference
+    })
   end
 
   describe 'caller identity propagation' do

--- a/spec/legion/llm/inference/pre_rollout_integration_spec.rb
+++ b/spec/legion/llm/inference/pre_rollout_integration_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe 'Pipeline pre-rollout integration' do
     stub_native_provider(content: 'pipeline response')
     Legion::LLM::Inventory.reset_live_store!
     Legion::LLM::Inventory.write_lane(lane: {
-      id: 'direct:test:default:inference:test-model',
+                                        id: 'direct:test:default:inference:test-model',
       tier: :direct, provider_family: :test, instance_id: :default,
       model: 'test-model', type: :inference
-    })
+                                      })
   end
 
   describe 'caller identity propagation' do

--- a/spec/legion/llm/prompt_spec.rb
+++ b/spec/legion/llm/prompt_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe Legion::LLM::Prompt do
     end
 
     context 'when no inventory lane is available' do
+      before do
+        Legion::LLM::Inventory.reset_live_store!
+        write_test_lane(provider: :anthropic, model: 'claude-sonnet-4-6', tier: :frontier)
+      end
+
       it 'falls back to default_provider and default_model' do
         result = described_class.dispatch('Hello')
         expect(result).to be_a(Legion::LLM::Inference::Response)
@@ -96,6 +101,8 @@ RSpec.describe Legion::LLM::Prompt do
     context 'when defaults are configured' do
       before do
         allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+        Legion::LLM::Inventory.reset_live_store!
+        write_test_lane(provider: :anthropic, model: 'claude-sonnet-4-6', tier: :frontier)
         Legion::Settings.set_prop(:llm, {
                                     default_provider: 'anthropic',
                                     default_model:    'claude-sonnet-4-6'

--- a/spec/legion/llm/prompt_spec.rb
+++ b/spec/legion/llm/prompt_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Legion::LLM::Prompt do
     context 'when Router is not enabled and no defaults exist' do
       before do
         allow(Legion::LLM::Router).to receive(:routing_enabled?).and_return(false)
+        Legion::LLM::Inventory.reset_live_store!
         Legion::Settings[:llm][:default_provider] = nil
         Legion::Settings[:llm][:default_model] = nil
       end
@@ -176,6 +177,8 @@ RSpec.describe Legion::LLM::Prompt do
           ]
         }
         Legion::LLM::Router.reset!
+        Legion::LLM::Inventory.reset_live_store!
+        write_test_lane(provider: :anthropic, model: 'claude-sonnet-4-6', tier: :cloud)
       end
 
       after { Legion::LLM::Router.reset! }
@@ -217,6 +220,8 @@ RSpec.describe Legion::LLM::Prompt do
     end
 
     context 'with nil provider' do
+      before { Legion::LLM::Inventory.reset_live_store! }
+
       it 'raises LLMError' do
         expect { described_class.request('Hello', provider: nil, model: 'claude-sonnet-4-6') }.to raise_error(
           Legion::LLM::LLMError, /provider.*must be set/i
@@ -225,6 +230,8 @@ RSpec.describe Legion::LLM::Prompt do
     end
 
     context 'with nil model' do
+      before { Legion::LLM::Inventory.reset_live_store! }
+
       it 'raises LLMError' do
         expect { described_class.request('Hello', provider: :anthropic, model: nil) }.to raise_error(
           Legion::LLM::LLMError, /model.*must be set/i


### PR DESCRIPTION
…y has lanes

When Inventory is populated, Prompt.dispatch no longer fills in default_provider/default_model — lets the Executor's step_routing pick via request_lane with full context (weight, context_window, tools).

Fixes: requests >16K context from GAIA/lex-agentic getting locked to v100 via model filter and failing with ContextOverflow instead of routing to h200.

Cold boot (empty Inventory) still falls through to settings defaults.

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
